### PR TITLE
Support date_fields and time_zone parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,7 @@ Style/StringLiterals:
 
 Style/TrailingComma:
   Enabled: false
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Support date fields
 - Support time_zone parameter
 - Rename range_fields parameter as int_fields
+- Return a null query if an invalid query string is given
 
 ## 0.3.0
 - Add downcased_fields options and update case rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 - Change range fields to use integer
+- Support date fields
 
 ## 0.3.0
 - Add downcased_fields options and update case rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 - Change range fields to use integer
 - Support date fields
+- Support time_zone parameter
 
 ## 0.3.0
 - Add downcased_fields options and update case rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Change range fields to use integer
 - Support date fields
 - Support time_zone parameter
+- Rename range_fields parameter as int_fields
 
 ## 0.3.0
 - Add downcased_fields options and update case rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+- Change range fields to use integer
+
 ## 0.3.0
 - Add downcased_fields options and update case rule
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ query_builder.build("tag:ruby")
 #=> {"filtered"=>{"filter"=>{"bool"=>{"should"=>[{"prefix"=>{"tag"=>"ruby/"}}, {"term"=>{"tag"=>"ruby"}}]}}}}
 ```
 
-### range_fields
-Pass `:range_fields` option with `:filterable_fields` to enable range filtered queries.
+### int_fields
+Pass `:int_fields` option with `:filterable_fields` to enable range filtered queries.
 With this option, `stocks:>100` will hit documents stocked by greater than 100 users.
 
 ```rb
-query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["stocks"], range_fields: ["stocks"])
-#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"], @date_fields=nil, @time_zone=nil>
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["stocks"], int_fields: ["stocks"])
 
 query_builder.build("stocks:>100")
 #=> {"filtered"=>{"filter"=>{"range"=>{"stocks"=>{"gt"=>100}}}}}

--- a/README.md
+++ b/README.md
@@ -66,10 +66,21 @@ With this option, `stocks:>100` will hit documents stocked by greater than 100 u
 
 ```rb
 query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["stocks"], range_fields: ["stocks"])
-#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"]>
+#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"], @date_fields=nil>
 
 query_builder.build("stocks:>100")
 #=> {"filtered"=>{"filter"=>{"range"=>{"stocks"=>{"gt"=>100}}}}}
+```
+
+### date_fields
+Pass `:date_fields` option with `:filterable_fields` to enable date filtered queries.
+With this option, `created_at:<2015-04-01` will hit documents created before 2015-04-01.
+
+```rb
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["created_at"], date_fields: ["created_at"])
+
+query_builder.build("created_at:<2015-04-01")
+#=> {"filtered"=>{"filter"=>{"range"=>{"created_at"=>{"lt"=>"2015-04-01"}}}}}
 ```
 
 ### downcased_fields

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ With this option, `stocks:>100` will hit documents stocked by greater than 100 u
 
 ```rb
 query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["stocks"], range_fields: ["stocks"])
-#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"], @date_fields=nil>
+#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"], @date_fields=nil, @time_zone=nil>
 
 query_builder.build("stocks:>100")
 #=> {"filtered"=>{"filter"=>{"range"=>{"stocks"=>{"gt"=>100}}}}}
@@ -81,6 +81,16 @@ query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["crea
 
 query_builder.build("created_at:<2015-04-01")
 #=> {"filtered"=>{"filter"=>{"range"=>{"created_at"=>{"lt"=>"2015-04-01"}}}}}
+```
+
+### time_zone
+Pass `:time_zone` option to tell how move range field's input to UTC time based date.
+
+```rb
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["created_at"], date_fields: ["created_at"], time_zone: "+09:00")
+
+query_builder.build("created_at:<2015-04-16")
+#=> {"filtered"=>{"filter"=>{"range"=>{"created_at"=>{"lt"=>"2015-04-16","time_zone"=>"+09:00"}}}}}
 ```
 
 ### downcased_fields

--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ query_builder.build("tag:ruby")
 
 ### range_fields
 Pass `:range_fields` option with `:filterable_fields` to enable range filtered queries.
-With this option, `created_at:<2015-04-16` will hit documents created before 2015-04-16.
+With this option, `stocks:>100` will hit documents stocked by greater than 100 users.
 
 ```rb
-query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["created_at"], range_fields: ["created_at"])
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["stocks"], range_fields: ["stocks"])
+#=> #<Qiita::Elasticsearch::QueryBuilder:0x007fe96d6d5ed0 @filterable_fields=["stocks"], @hierarchal_fields=nil, @matchable_fields=nil, @range_fields=["stocks"]>
 
-query_builder.build("created_at:<2015-04-16")
-#=> {"filtered"=>{"filter"=>{"range"=>{"created_at"=>{"lt"=>"2015-04-16"}}}}}
+query_builder.build("stocks:>100")
+#=> {"filtered"=>{"filter"=>{"range"=>{"stocks"=>{"gt"=>100}}}}}
 ```
 
 ### downcased_fields

--- a/lib/qiita/elasticsearch/concerns/range_operand_includable.rb
+++ b/lib/qiita/elasticsearch/concerns/range_operand_includable.rb
@@ -1,0 +1,42 @@
+require "active_support/concern"
+
+module Qiita
+  module Elasticsearch
+    module Concerns
+      module RangeOperandIncludable
+        extend ActiveSupport::Concern
+
+        RANGE_TERM_REGEXP = /\A(?<operand>\<=|\<|\>=|\>)(?<query>.*)\z/
+
+        private
+
+        # @return [String, nil]
+        # @example Suppose @term is "created_at:>=2015-04-16"
+        #   range_parameter #=> "gte"
+        def range_parameter
+          range_match[:operand] ? operand_map[range_match[:operand]] : nil
+        end
+
+        # @return [String, nil]
+        # @example Suppose @term is "created_at:>=2015-04-16"
+        #   range_query #=> "2015-04-16"
+        def range_query
+          range_match[:query]
+        end
+
+        def range_match
+          @range_match ||= RANGE_TERM_REGEXP.match(@term) || {}
+        end
+
+        def operand_map
+          {
+            ">" => "gt",
+            ">=" => "gte",
+            "<" => "lt",
+            "<=" => "lte",
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/date_token.rb
+++ b/lib/qiita/elasticsearch/date_token.rb
@@ -18,6 +18,8 @@ module Qiita
         )?
       \z/x
 
+      attr_writer :time_zone
+
       # @return [Hash]
       def to_hash
         case
@@ -26,7 +28,10 @@ module Qiita
             "range" => {
               @field_name => {
                 range_parameter => range_query,
-              },
+                "time_zone" => @time_zone,
+              }.reject do |key, value|
+                key == "time_zone" && value.nil?
+              end,
             },
           }
         when date_match
@@ -35,7 +40,10 @@ module Qiita
               @field_name => {
                 "gte" => beginning_of_range.to_s,
                 "lt" => end_of_range.to_s,
-              },
+                "time_zone" => @time_zone,
+              }.reject do |key, value|
+                key == "time_zone" && value.nil?
+              end,
             },
           }
         else

--- a/lib/qiita/elasticsearch/date_token.rb
+++ b/lib/qiita/elasticsearch/date_token.rb
@@ -1,0 +1,83 @@
+require "active_support/core_ext/date"
+require "active_support/core_ext/integer"
+require "qiita/elasticsearch/range_token"
+
+module Qiita
+  module Elasticsearch
+    class DateToken < RangeToken
+      # @note Matches to "YYYY", "YYYY-MM" and "YYYY-MM-DD"
+      DATE_REGEXP = /\A
+        (?<year>\d{4})
+        (?:
+          -
+          (?<month>\d{1,2})
+          (?:
+            -
+            (?<day>\d{1,2})
+          )?
+        )?
+      \z/x
+
+      # @return [Hash]
+      def to_hash
+        case
+        when range_parameter
+          {
+            "range" => {
+              @field_name => {
+                range_parameter => range_query,
+              },
+            },
+          }
+        when date_match
+          {
+            "range" => {
+              @field_name => {
+                "gte" => beginning_of_range.to_s,
+                "lt" => end_of_range.to_s,
+              },
+            },
+          }
+        else
+          {
+            "term" => {
+              @field_name => downcased_term,
+            },
+          }
+        end
+      end
+
+      private
+
+      def date_match
+        @date_match ||= DATE_REGEXP.match(range_query || @term)
+      end
+
+      # @return [Date]
+      def beginning_of_range
+        @beginning_of_range ||=
+          case
+          when date_match[:day]
+            Date.new(date_match[:year].to_i, date_match[:month].to_i, date_match[:day].to_i)
+          when date_match[:month]
+            Date.new(date_match[:year].to_i, date_match[:month].to_i)
+          else
+            Date.new(date_match[:year].to_i)
+          end
+      end
+
+      # @return [Date]
+      def end_of_range
+        @end_of_range ||=
+          case
+          when date_match[:day]
+            beginning_of_range + 1.day
+          when date_match[:month]
+            beginning_of_range + 1.month
+          else
+            beginning_of_range + 1.year
+          end
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/date_token.rb
+++ b/lib/qiita/elasticsearch/date_token.rb
@@ -1,10 +1,13 @@
 require "active_support/core_ext/date"
 require "active_support/core_ext/integer"
-require "qiita/elasticsearch/range_token"
+require "qiita/elasticsearch/concerns/range_operand_includable"
+require "qiita/elasticsearch/token"
 
 module Qiita
   module Elasticsearch
-    class DateToken < RangeToken
+    class DateToken < Token
+      include Concerns::RangeOperandIncludable
+
       # @note Matches to "YYYY", "YYYY-MM" and "YYYY-MM-DD"
       DATE_REGEXP = /\A
         (?<year>\d{4})

--- a/lib/qiita/elasticsearch/errors.rb
+++ b/lib/qiita/elasticsearch/errors.rb
@@ -1,0 +1,10 @@
+module Qiita
+  module Elasticsearch
+    # @note Custom error class for rescuing from all Qiita::Elasticsearch errors.
+    class Error < StandardError
+    end
+
+    class InvalidQuery < Error
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/int_token.rb
+++ b/lib/qiita/elasticsearch/int_token.rb
@@ -1,0 +1,29 @@
+require "qiita/elasticsearch/concerns/range_operand_includable"
+require "qiita/elasticsearch/token"
+
+module Qiita
+  module Elasticsearch
+    class IntToken < Token
+      include Concerns::RangeOperandIncludable
+
+      # @return [Hash]
+      def to_hash
+        if range_parameter
+          {
+            "range" => {
+              @field_name => {
+                range_parameter => range_query.to_i,
+              },
+            },
+          }
+        else
+          {
+            "term" => {
+              @field_name => downcased_term.to_i,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -5,15 +5,17 @@ require "qiita/elasticsearch/tokenizer"
 module Qiita
   module Elasticsearch
     class QueryBuilder
+      # @param [Array<String>, nil] date_fields
       # @param [Array<String>, nil] downcased_fields
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] matchable_fields
       # @param [Array<String>, nil] range_fields
-      def initialize(downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, matchable_fields: nil, range_fields: nil)
+      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, matchable_fields: nil, range_fields: nil)
+        @date_fields = date_fields
         @downcased_fields = downcased_fields
-        @hierarchal_fields = hierarchal_fields
         @filterable_fields = filterable_fields
+        @hierarchal_fields = hierarchal_fields
         @matchable_fields = matchable_fields
         @range_fields = range_fields
       end
@@ -33,9 +35,10 @@ module Qiita
 
       def tokenizer
         @tokenizer ||= Tokenizer.new(
+          date_fields: @date_fields,
           downcased_fields: @downcased_fields,
-          hierarchal_fields: @hierarchal_fields,
           filterable_fields: @filterable_fields,
+          hierarchal_fields: @hierarchal_fields,
           matchable_fields: @matchable_fields,
           range_fields: @range_fields,
         )

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -11,13 +11,15 @@ module Qiita
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] matchable_fields
       # @param [Array<String>, nil] range_fields
-      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, matchable_fields: nil, range_fields: nil)
+      # @param [String, nil] time_zone
+      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, matchable_fields: nil, range_fields: nil, time_zone: nil)
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
         @matchable_fields = matchable_fields
         @range_fields = range_fields
+        @time_zone = time_zone
       end
 
       # @param [String] query_string Raw query string
@@ -41,6 +43,7 @@ module Qiita
           hierarchal_fields: @hierarchal_fields,
           matchable_fields: @matchable_fields,
           range_fields: @range_fields,
+          time_zone: @time_zone,
         )
       end
     end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -9,16 +9,16 @@ module Qiita
       # @param [Array<String>, nil] downcased_fields
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
+      # @param [Array<String>, nil] int_fields
       # @param [Array<String>, nil] matchable_fields
-      # @param [Array<String>, nil] range_fields
       # @param [String, nil] time_zone
-      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, matchable_fields: nil, range_fields: nil, time_zone: nil)
+      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
+        @int_fields = int_fields
         @matchable_fields = matchable_fields
-        @range_fields = range_fields
         @time_zone = time_zone
       end
 
@@ -41,8 +41,8 @@ module Qiita
           downcased_fields: @downcased_fields,
           filterable_fields: @filterable_fields,
           hierarchal_fields: @hierarchal_fields,
+          int_fields: @int_fields,
           matchable_fields: @matchable_fields,
-          range_fields: @range_fields,
           time_zone: @time_zone,
         )
       end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -1,3 +1,4 @@
+require "qiita/elasticsearch/errors"
 require "qiita/elasticsearch/nodes/null_node"
 require "qiita/elasticsearch/nodes/or_separatable_node"
 require "qiita/elasticsearch/tokenizer"
@@ -31,6 +32,8 @@ module Qiita
         else
           Nodes::OrSeparatableNode.new(tokens).to_hash
         end
+      rescue Error
+        Nodes::NullNode.new.to_hash
       end
 
       private

--- a/lib/qiita/elasticsearch/range_token.rb
+++ b/lib/qiita/elasticsearch/range_token.rb
@@ -3,7 +3,7 @@ require "qiita/elasticsearch/token"
 module Qiita
   module Elasticsearch
     class RangeToken < Token
-      RANGE_TERM_REGEXP = /\A(?<operand>\<|\<=|\>|\>=)(?<query>.*)\z/
+      RANGE_TERM_REGEXP = /\A(?<operand>\<=|\<|\>=|\>)(?<query>.*)\z/
 
       # @return [Hash]
       def to_hash

--- a/lib/qiita/elasticsearch/range_token.rb
+++ b/lib/qiita/elasticsearch/range_token.rb
@@ -11,14 +11,14 @@ module Qiita
           {
             "range" => {
               @field_name => {
-                range_parameter => range_query,
+                range_parameter => range_query.to_i,
               },
             },
           }
         else
           {
             "term" => {
-              @field_name => proper_cased_term,
+              @field_name => proper_cased_term.to_i,
             },
           }
         end

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -2,7 +2,7 @@ require "qiita/elasticsearch/date_token"
 require "qiita/elasticsearch/filterable_token"
 require "qiita/elasticsearch/hierarchal_token"
 require "qiita/elasticsearch/matchable_token"
-require "qiita/elasticsearch/range_token"
+require "qiita/elasticsearch/int_token"
 
 module Qiita
   module Elasticsearch
@@ -11,7 +11,7 @@ module Qiita
       DEFAULT_DOWNCASED_FIELDS = []
       DEFAULT_FILTERABLE_FIELDS = []
       DEFAULT_HIERARCHAL_FIELDS = []
-      DEFAULT_RANGE_FIELDS = []
+      DEFAULT_INT_FIELDS = []
 
       TOKEN_PATTERN = /
         (?<token_string>
@@ -29,16 +29,16 @@ module Qiita
       # @param [Array<String>, nil] downcased_fields
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
+      # @param [Array<String>, nil] int_fields
       # @param [Array<String>, nil] matchable_fields
-      # @param [Array<String>, nil] range_fields
       # @param [String, nil] time_zone
-      def initialize(date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil, time_zone: nil)
+      def initialize(date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
+        @int_fields = int_fields
         @matchable_fields = matchable_fields
-        @range_fields = range_fields
         @time_zone = time_zone
       end
 
@@ -83,16 +83,16 @@ module Qiita
         @hierarchal_fields || DEFAULT_HIERARCHAL_FIELDS
       end
 
-      def range_fields
-        @range_fields || DEFAULT_RANGE_FIELDS
+      def int_fields
+        @int_fields || DEFAULT_INT_FIELDS
       end
 
       def token_class(field_name)
         case
         when date_fields.include?(field_name)
           DateToken
-        when range_fields.include?(field_name)
-          RangeToken
+        when int_fields.include?(field_name)
+          IntToken
         when hierarchal_fields.include?(field_name)
           HierarchalToken
         when filterable_fields.include?(field_name)

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -1,3 +1,4 @@
+require "qiita/elasticsearch/date_token"
 require "qiita/elasticsearch/filterable_token"
 require "qiita/elasticsearch/hierarchal_token"
 require "qiita/elasticsearch/matchable_token"
@@ -6,6 +7,7 @@ require "qiita/elasticsearch/range_token"
 module Qiita
   module Elasticsearch
     class Tokenizer
+      DEFAULT_DATE_FIELDS = []
       DEFAULT_DOWNCASED_FIELDS = []
       DEFAULT_FILTERABLE_FIELDS = []
       DEFAULT_HIERARCHAL_FIELDS = []
@@ -23,12 +25,14 @@ module Qiita
         )
       /x
 
+      # @param [Array<String>, nil] date_fields
       # @param [Array<String>, nil] downcased_fields
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] matchable_fields
       # @param [Array<String>, nil] range_fields
-      def initialize(downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
+      def initialize(date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
+        @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
@@ -60,6 +64,10 @@ module Qiita
 
       private
 
+      def date_fields
+        @date_fields || DEFAULT_DATE_FIELDS
+      end
+
       def downcased_fields
         @downcased_fields || DEFAULT_DOWNCASED_FIELDS
       end
@@ -78,6 +86,8 @@ module Qiita
 
       def token_class(field_name)
         case
+        when date_fields.include?(field_name)
+          DateToken
         when range_fields.include?(field_name)
           RangeToken
         when hierarchal_fields.include?(field_name)

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -31,13 +31,15 @@ module Qiita
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] matchable_fields
       # @param [Array<String>, nil] range_fields
-      def initialize(date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
+      # @param [String, nil] time_zone
+      def initialize(date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil, time_zone: nil)
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
         @matchable_fields = matchable_fields
         @range_fields = range_fields
+        @time_zone = time_zone
       end
 
       # @param [String] query_string Raw query string
@@ -58,6 +60,7 @@ module Qiita
             token_string: token_string,
           )
           token.matchable_fields = @matchable_fields if token.is_a?(MatchableToken)
+          token.time_zone = @time_zone if token.is_a?(DateToken)
           token
         end
       end

--- a/qiita-elasticsearch.gemspec
+++ b/qiita-elasticsearch.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -515,16 +515,34 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
     context "with range field name" do
       let(:filterable_fields) do
-        ["created_at"]
+        ["stocks"]
       end
 
       let(:range_fields) do
-        ["created_at"]
+        ["stocks"]
+      end
+
+      context "and query does not consist of digits" do
+        let(:query_string) do
+          "stocks:aaa"
+        end
+
+        it "treats the query as 0" do
+          is_expected.to eq(
+            "filtered" => {
+              "filter" => {
+                "term" => {
+                  "stocks" => 0,
+                },
+              },
+            },
+          )
+        end
       end
 
       context "and no range operand" do
         let(:query_string) do
-          "created_at:2012-02-29"
+          "stocks:100"
         end
 
         it "returns term filter" do
@@ -532,7 +550,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             "filtered" => {
               "filter" => {
                 "term" => {
-                  "created_at" =>  "2012-02-29"
+                  "stocks" => 100,
                 },
               },
             },
@@ -542,7 +560,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       context "and < operand" do
         let(:query_string) do
-          "created_at:<2012-02-29"
+          "stocks:<100"
         end
 
         it "returns range filter" do
@@ -550,8 +568,8 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             "filtered" => {
               "filter" => {
                 "range" => {
-                  "created_at" => {
-                    "lt" => "2012-02-29"
+                  "stocks" => {
+                    "lt" => 100,
                   },
                 },
               },
@@ -562,7 +580,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       context "and > operand" do
         let(:query_string) do
-          "created_at:>2012-02-29"
+          "stocks:>100"
         end
 
         it "returns range filter" do
@@ -570,8 +588,8 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             "filtered" => {
               "filter" => {
                 "range" => {
-                  "created_at" => {
-                    "gt" => "2012-02-29"
+                  "stocks" => {
+                    "gt" => 100,
                   },
                 },
               },
@@ -580,9 +598,9 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         end
       end
 
-      context "and both < and > operands" do
+      context "and multiple operands" do
         let(:query_string) do
-          "created_at:>2012-02-29 created_at:<2013-02-28"
+          "stocks:>=100 stocks:<=200"
         end
 
         it "returns two range filters within bool filter" do
@@ -594,15 +612,15 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
                   "must" => [
                     {
                       "range" => {
-                        "created_at" => {
-                          "gt" => "2012-02-29",
+                        "stocks" => {
+                          "gte" => 100,
                         },
                       },
                     },
                     {
                       "range" => {
-                        "created_at" => {
-                          "lt" => "2013-02-28",
+                        "stocks" => {
+                          "lte" => 200,
                         },
                       },
                     },

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
     let(:matchable_fields) do
     end
 
-    let(:range_fields) do
+    let(:int_fields) do
     end
 
     let(:date_fields) do
@@ -33,7 +33,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         filterable_fields: filterable_fields,
         hierarchal_fields: hierarchal_fields,
         matchable_fields: matchable_fields,
-        range_fields: range_fields,
+        int_fields: int_fields,
         date_fields: date_fields,
         time_zone: time_zone,
       }
@@ -526,7 +526,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         ["stocks"]
       end
 
-      let(:range_fields) do
+      let(:int_fields) do
         ["stocks"]
       end
 

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -535,13 +535,11 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
           "stocks:aaa"
         end
 
-        it "treats the query as 0" do
+        it "returns null query that matches with nothing" do
           is_expected.to eq(
-            "filtered" => {
-              "filter" => {
-                "term" => {
-                  "stocks" => 0,
-                },
+            "query" => {
+              "ids" => {
+                "values" => [],
               },
             },
           )
@@ -655,13 +653,11 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
           "created_at:aaa"
         end
 
-        it "returns term filter" do
+        it "returns null query that matches with nothing" do
           is_expected.to eq(
-            "filtered" => {
-              "filter" => {
-                "term" => {
-                  "created_at" => "aaa",
-                },
+            "query" => {
+              "ids" => {
+                "values" => [],
               },
             },
           )

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
     let(:date_fields) do
     end
 
+    let(:time_zone) do
+    end
+
     let(:properties) do
       {
         downcased_fields: downcased_fields,
@@ -32,6 +35,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         matchable_fields: matchable_fields,
         range_fields: range_fields,
         date_fields: date_fields,
+        time_zone: time_zone,
       }
     end
 
@@ -727,9 +731,35 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             )
           end
         end
+
+        context "and time_zone" do
+          let(:time_zone) do
+            "+09:00"
+          end
+
+          let(:query_string) do
+            "created_at:2015-04-17"
+          end
+
+          it "returns range filter with time_zone" do
+            is_expected.to eq(
+              "filtered" => {
+                "filter" => {
+                  "range" => {
+                    "created_at" => {
+                      "gte" => "2015-04-17",
+                      "lt" => "2015-04-18",
+                      "time_zone" => time_zone,
+                    }
+                  },
+                },
+              },
+            )
+          end
+        end
       end
 
-      context "and < operand" do
+      context "and single operand" do
         let(:query_string) do
           "created_at:<2015-04"
         end
@@ -747,25 +777,26 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             },
           )
         end
-      end
 
-      context "and > operand" do
-        let(:query_string) do
-          "created_at:>2015-04"
-        end
+        context "and time_zone" do
+          let(:time_zone) do
+            "+09:00"
+          end
 
-        it "returns range filter" do
-          is_expected.to eq(
-            "filtered" => {
-              "filter" => {
-                "range" => {
-                  "created_at" => {
-                    "gt" => "2015-04",
+          it "returns range filter with time_zone" do
+            is_expected.to eq(
+              "filtered" => {
+                "filter" => {
+                  "range" => {
+                    "created_at" => {
+                      "lt" => "2015-04",
+                      "time_zone" => time_zone,
+                    },
                   },
                 },
               },
-            },
-          )
+            )
+          end
         end
       end
 


### PR DESCRIPTION
Add date_fields and time_zone parameters.

An exact query with a field in date_fields is automatically converted to a range query. Example:

given | converted
----|----
created_at:2014 | created_at:>=2014-01-01 created_at:<2015-01-01
created_at:2014-01 | created_at:>=2014-01-01 created_at:<2014-02-01
created_at:2014-01-01 | craeted_at:>=2014-01-01 created_at:<2014-01-02

See http://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-range-filter.html#query-dsl-range-filter for how time_zone parameter works. Note that the time_zone parameter is added to elasticsearch in 1.4.0.Beta1.