### PR TITLE
Refactor by introducing token classes

### DIFF
--- a/lib/qiita/elasticsearch/filterable_token.rb
+++ b/lib/qiita/elasticsearch/filterable_token.rb
@@ -1,0 +1,16 @@
+require "qiita/elasticsearch/token"
+
+module Qiita
+  module Elasticsearch
+    class FilterableToken < Token
+      # @return [Hash]
+      def to_hash
+        {
+          "term" => {
+            @field_name => downcased_term,
+          },
+        }
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/hierarchal_token.rb
+++ b/lib/qiita/elasticsearch/hierarchal_token.rb
@@ -1,0 +1,27 @@
+require "qiita/elasticsearch/token"
+
+module Qiita
+  module Elasticsearch
+    class HierarchalToken < Token
+      # @return [Hash]
+      def to_hash
+        {
+          "bool" => {
+            "should" => [
+              {
+                "prefix" => {
+                  @field_name => downcased_term + "/",
+                },
+              },
+              {
+                "term" => {
+                  @field_name => downcased_term,
+                },
+              },
+            ],
+          },
+        }
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/matchable_token.rb
+++ b/lib/qiita/elasticsearch/matchable_token.rb
@@ -1,0 +1,29 @@
+require "qiita/elasticsearch/token"
+
+module Qiita
+  module Elasticsearch
+    class MatchableToken < Token
+      attr_writer :matchable_fields
+
+      # @return [Hash]
+      def to_hash
+        if @matchable_fields.nil?
+          {
+            quoted? ? "match_phrase" : "match" => {
+              "_all" => @term,
+            }
+          }
+        else
+          hash = {
+            "multi_match" => {
+              "fields" => @matchable_fields,
+              "query" => @term,
+            },
+          }
+          hash["multi_match"]["type"] = "phrase" if quoted?
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/nodes/filter_node.rb
+++ b/lib/qiita/elasticsearch/nodes/filter_node.rb
@@ -6,23 +6,13 @@ module Qiita
     module Nodes
       class FilterNode
         # @param [Array<Qiita::Elasticsearch::Tokens>] tokens
-        # @param [Array<String>, nil] hierarchal_fields
-        # @param [Array<String>, nil] matchable_fields
-        # @param [Array<String>, nil] range_fields
-        def initialize(tokens, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
-          @hierarchal_fields = hierarchal_fields
-          @matchable_fields = matchable_fields
-          @range_fields = range_fields
+        def initialize(tokens)
           @tokens = tokens
         end
 
         def to_hash
           if must_not_tokens.empty? && must_tokens.length == 1
-            TermNode.new(
-              must_tokens.first,
-              hierarchal_fields: @hierarchal_fields,
-              range_fields: @range_fields,
-            ).to_hash
+            TermNode.new(must_tokens.first).to_hash
           else
             {
               "bool" => {
@@ -41,17 +31,10 @@ module Qiita
         def must_not_queries
           must_not_tokens.map do |token|
             if token.field_name.nil?
-              MatchNode.new(
-                token,
-                matchable_fields: @matchable_fields,
-              )
+              MatchNode.new(token).to_hash
             else
-              TermNode.new(
-                token,
-                hierarchal_fields: @hierarchal_fields,
-                range_fields: @range_fields,
-              )
-            end.to_hash
+              TermNode.new(token).to_hash
+            end
           end
         end
 
@@ -61,11 +44,7 @@ module Qiita
 
         def must_queries
           must_tokens.map do |token|
-            TermNode.new(
-              token,
-              hierarchal_fields: @hierarchal_fields,
-              range_fields: @range_fields,
-            ).to_hash
+            TermNode.new(token).to_hash
           end
         end
 

--- a/lib/qiita/elasticsearch/nodes/filterable_node.rb
+++ b/lib/qiita/elasticsearch/nodes/filterable_node.rb
@@ -6,35 +6,18 @@ module Qiita
     module Nodes
       class FilterableNode
         # @param [Array<Qiita::Elasticsearch::Tokens>] tokens
-        # @param [Array<String>, nil] hierarchal_fields
-        # @param [Array<String>, nil] matchable_fields
-        # @param [Array<String>, nil] range_fields
-        def initialize(tokens, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
-          @hierarchal_fields = hierarchal_fields
-          @matchable_fields = matchable_fields
-          @range_fields = range_fields
+        def initialize(tokens)
           @tokens = tokens
         end
 
         def to_hash
           if filter_tokens.empty?
-            QueryNode.new(
-              not_filter_tokens,
-              matchable_fields: @matchable_fields,
-            ).to_hash
+            QueryNode.new(not_filter_tokens).to_hash
           else
             {
               "filtered" => {
-                "filter" => FilterNode.new(
-                  filter_tokens,
-                  hierarchal_fields: @hierarchal_fields,
-                  matchable_fields: @matchable_fields,
-                  range_fields: @range_fields,
-                ).to_hash,
-                "query" => QueryNode.new(
-                  not_filter_tokens,
-                  matchable_fields: @matchable_fields,
-                ).to_hash,
+                "filter" => FilterNode.new(filter_tokens).to_hash,
+                "query" => QueryNode.new(not_filter_tokens).to_hash,
               }.reject do |key, value|
                 value.empty?
               end,

--- a/lib/qiita/elasticsearch/nodes/match_node.rb
+++ b/lib/qiita/elasticsearch/nodes/match_node.rb
@@ -3,29 +3,13 @@ module Qiita
     module Nodes
       class MatchNode
         # @param [Qiita::Elasticsearch::Token] token
-        # @param [Array<String>, nil] matchable_fields
-        def initialize(token, matchable_fields: nil)
-          @matchable_fields = matchable_fields
+        def initialize(token)
           @token = token
         end
 
+        # @return [Hash]
         def to_hash
-          if @matchable_fields.nil?
-            {
-              @token.quoted? ? "match_phrase" : "match" => {
-                "_all" => @token.term,
-              }
-            }
-          else
-            hash = {
-              "multi_match" => {
-                "fields" => @matchable_fields,
-                "query" => @token.term,
-              },
-            }
-            hash["multi_match"]["type"] = "phrase" if @token.quoted?
-            hash
-          end
+          @token.to_hash
         end
       end
     end

--- a/lib/qiita/elasticsearch/nodes/multi_should_node.rb
+++ b/lib/qiita/elasticsearch/nodes/multi_should_node.rb
@@ -5,9 +5,7 @@ module Qiita
     module Nodes
       class MultiShouldNode
         # @param [Array<Qiita::Elasticsearch::Tokens>] tokens
-        # @param [Array<String>, nil] matchable_fields
-        def initialize(tokens, matchable_fields: nil)
-          @matchable_fields = matchable_fields
+        def initialize(tokens)
           @tokens = tokens
         end
 
@@ -24,10 +22,7 @@ module Qiita
         # @return [Array<Hash>] Queries to be used as a value of `should` property of bool query.
         def should_queries
           @tokens.map do |token|
-            MatchNode.new(
-              token,
-              matchable_fields: @matchable_fields,
-            ).to_hash
+            MatchNode.new(token).to_hash
           end
         end
       end

--- a/lib/qiita/elasticsearch/nodes/or_separatable_node.rb
+++ b/lib/qiita/elasticsearch/nodes/or_separatable_node.rb
@@ -6,13 +6,7 @@ module Qiita
     module Nodes
       class OrSeparatableNode
         # @param [Array<Qiita::Elasticsearch::Tokens>] tokens
-        # @param [Array<String>, nil] hierarchal_fields
-        # @param [Array<String>, nil] matchable_fields
-        # @param [Array<String>, nil] range_fields
-        def initialize(tokens, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
-          @hierarchal_fields = hierarchal_fields
-          @matchable_fields = matchable_fields
-          @range_fields = range_fields
+        def initialize(tokens)
           @tokens = tokens
         end
 
@@ -21,22 +15,12 @@ module Qiita
           when 0
             Nodes::NullNode.new.to_hash
           when 1
-            Nodes::FilterableNode.new(
-              tokens_grouped_by_or_token.first,
-              hierarchal_fields: @hierarchal_fields,
-              matchable_fields: @matchable_fields,
-              range_fields: @range_fields,
-            ).to_hash
+            Nodes::FilterableNode.new(tokens_grouped_by_or_token.first).to_hash
           else
             {
               "bool" => {
                 "should" => tokens_grouped_by_or_token.map do |tokens|
-                  Nodes::FilterableNode.new(
-                    tokens,
-                    hierarchal_fields: @hierarchal_fields,
-                    matchable_fields: @matchable_fields,
-                    range_fields: @range_fields,
-                  ).to_hash
+                  Nodes::FilterableNode.new(tokens).to_hash
                 end,
               },
             }

--- a/lib/qiita/elasticsearch/nodes/query_node.rb
+++ b/lib/qiita/elasticsearch/nodes/query_node.rb
@@ -6,10 +6,7 @@ module Qiita
     module Nodes
       class QueryNode
         # @param [Array<Qiita::Elasticsearch::Tokens>] tokens
-        # @param [Array<String>, nil] matchable_fields
-        def initialize(tokens, hierarchal_fields: nil, matchable_fields: nil)
-          @hierarchal_fields = hierarchal_fields
-          @matchable_fields = matchable_fields
+        def initialize(tokens)
           @tokens = tokens
         end
 
@@ -18,15 +15,9 @@ module Qiita
           when 0
             {}
           when 1
-            MatchNode.new(
-              @tokens.first,
-              matchable_fields: @matchable_fields,
-            ).to_hash
+            MatchNode.new(@tokens.first).to_hash
           else
-            MultiShouldNode.new(
-              @tokens,
-              matchable_fields: @matchable_fields,
-            ).to_hash
+            MultiShouldNode.new(@tokens).to_hash
           end
         end
       end

--- a/lib/qiita/elasticsearch/nodes/term_node.rb
+++ b/lib/qiita/elasticsearch/nodes/term_node.rb
@@ -2,71 +2,14 @@ module Qiita
   module Elasticsearch
     module Nodes
       class TermNode
-        DEFAULT_HIERARCHAL_FIELDS = []
-        DEFAULT_RANGE_FIELDS = []
-
         # @param [Qiita::Elasticsearch::Token] token
-        # @param [Array<String>, nil] hierarchal_fields
-        # @param [Array<String>, nil] range_fields
-        def initialize(token, hierarchal_fields: nil, range_fields: nil)
-          @hierarchal_fields = hierarchal_fields
-          @range_fields = range_fields
+        def initialize(token)
           @token = token
         end
 
         # @return [Hash]
         def to_hash
-          case
-          when has_hierarchal_token?
-            {
-              "bool" => {
-                "should" => [
-                  {
-                    "prefix" => {
-                      @token.field_name => @token.downcased_term + "/",
-                    },
-                  },
-                  {
-                    "term" => {
-                      @token.field_name => @token.downcased_term,
-                    },
-                  },
-                ],
-              },
-            }
-          when has_range_token?
-            {
-              "range" => {
-                @token.field_name => {
-                  @token.range_parameter => @token.range_query,
-                },
-              },
-            }
-          else
-            {
-              "term" => {
-                @token.field_name => @token.downcased_term,
-              },
-            }
-          end
-        end
-
-        private
-
-        def has_hierarchal_token?
-          hierarchal_fields.include?(@token.field_name)
-        end
-
-        def hierarchal_fields
-          @hierarchal_fields || DEFAULT_HIERARCHAL_FIELDS
-        end
-
-        def has_range_token?
-          range_fields.include?(@token.field_name) && @token.range_parameter
-        end
-
-        def range_fields
-          @range_fields || DEFAULT_RANGE_FIELDS
+          @token.to_hash
         end
       end
     end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -23,19 +23,19 @@ module Qiita
         if tokens.size.zero?
           Nodes::NullNode.new.to_hash
         else
-          Nodes::OrSeparatableNode.new(
-            tokens,
-            hierarchal_fields: @hierarchal_fields,
-            matchable_fields: @matchable_fields,
-            range_fields: @range_fields,
-          ).to_hash
+          Nodes::OrSeparatableNode.new(tokens).to_hash
         end
       end
 
       private
 
       def tokenizer
-        @tokenizer ||= Tokenizer.new(filterable_fields: @filterable_fields)
+        @tokenizer ||= Tokenizer.new(
+          hierarchal_fields: @hierarchal_fields,
+          filterable_fields: @filterable_fields,
+          matchable_fields: @matchable_fields,
+          range_fields: @range_fields,
+        )
       end
     end
   end

--- a/lib/qiita/elasticsearch/range_token.rb
+++ b/lib/qiita/elasticsearch/range_token.rb
@@ -1,0 +1,57 @@
+require "qiita/elasticsearch/token"
+
+module Qiita
+  module Elasticsearch
+    class RangeToken < Token
+      RANGE_TERM_REGEXP = /\A(?<operand>\<|\<=|\>|\>=)(?<query>.*)\z/
+
+      # @return [Hash]
+      def to_hash
+        if range_parameter
+          {
+            "range" => {
+              @field_name => {
+                range_parameter => range_query,
+              },
+            },
+          }
+        else
+          {
+            "term" => {
+              @field_name => downcased_term,
+            },
+          }
+        end
+      end
+
+      private
+
+      # @return [String, nil]
+      # @example Suppose @term is "created_at:>=2015-04-16"
+      #   range_parameter #=> "gte"
+      def range_parameter
+        range_match[:operand] ? operand_map[range_match[:operand]] : nil
+      end
+
+      # @return [String, nil]
+      # @example Suppose @term is "created_at:>=2015-04-16"
+      #   range_query #=> "2015-04-16"
+      def range_query
+        range_match[:query]
+      end
+
+      def range_match
+        @range_match ||= RANGE_TERM_REGEXP.match(@term) || {}
+      end
+
+      def operand_map
+        {
+          ">" => "gt",
+          ">=" => "gte",
+          "<" => "lt",
+          "<=" => "lte",
+        }
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/token.rb
+++ b/lib/qiita/elasticsearch/token.rb
@@ -1,8 +1,6 @@
 module Qiita
   module Elasticsearch
     class Token
-      RANGE_TERM_REGEXP = /\A(?<operand>\<|\<=|\>|\>=)(?<query>.*)\z/
-
       attr_reader :field_name, :term
 
       def initialize(field_name: nil, minus: nil, quoted: nil, term: nil, token_string: nil)
@@ -15,6 +13,10 @@ module Qiita
 
       def downcased_term
         @downcased_term ||= term.downcase
+      end
+
+      def to_hash
+        fail NotImplementedError
       end
 
       def filter?
@@ -56,35 +58,6 @@ module Qiita
       #                        This
       def quoted?
         !!@quoted
-      end
-
-      # @return [String, nil]
-      # @example Suppose @term is "created_at:>=2015-04-16"
-      #   range_parameter #=> "gte"
-      def range_parameter
-        range_match[:operand] ? operand_map[range_match[:operand]] : nil
-      end
-
-      # @return [String, nil]
-      # @example Suppose @term is "created_at:>=2015-04-16"
-      #   range_query #=> "2015-04-16"
-      def range_query
-        range_match[:query]
-      end
-
-      private
-
-      def range_match
-        @range_match ||= RANGE_TERM_REGEXP.match(@term) || {}
-      end
-
-      def operand_map
-        {
-          ">" => "gt",
-          ">=" => "gte",
-          "<" => "lt",
-          "<=" => "lte",
-        }
       end
     end
   end

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -1,9 +1,14 @@
-require "qiita/elasticsearch/token"
+require "qiita/elasticsearch/filterable_token"
+require "qiita/elasticsearch/hierarchal_token"
+require "qiita/elasticsearch/matchable_token"
+require "qiita/elasticsearch/range_token"
 
 module Qiita
   module Elasticsearch
     class Tokenizer
       DEFAULT_FILTERABLE_FIELDS = []
+      DEFAULT_HIERARCHAL_FIELDS = []
+      DEFAULT_RANGE_FIELDS = []
 
       TOKEN_PATTERN = /
         (?<token_string>
@@ -18,8 +23,14 @@ module Qiita
       /x
 
       # @param [Array<String>, nil] filterable_fields
-      def initialize(filterable_fields: nil)
+      # @param [Array<String>, nil] hierarchal_fields
+      # @param [Array<String>, nil] matchable_fields
+      # @param [Array<String>, nil] range_fields
+      def initialize(filterable_fields: nil, hierarchal_fields: nil, matchable_fields: nil, range_fields: nil)
         @filterable_fields = filterable_fields
+        @hierarchal_fields = hierarchal_fields
+        @matchable_fields = matchable_fields
+        @range_fields = range_fields
       end
 
       # @param [String] query_string Raw query string
@@ -31,20 +42,43 @@ module Qiita
             term = "#{field_name}:#{term}"
             field_name = nil
           end
-          Token.new(
+          token = token_class(field_name).new(
             field_name: field_name,
             minus: minus,
             quoted: !quoted_term.nil?,
             term: term,
             token_string: token_string,
           )
+          token.matchable_fields = @matchable_fields if token.is_a?(MatchableToken)
+          token
         end
       end
 
       private
 
+      def token_class(field_name)
+        case
+        when range_fields.include?(field_name)
+          RangeToken
+        when hierarchal_fields.include?(field_name)
+          HierarchalToken
+        when filterable_fields.include?(field_name)
+          FilterableToken
+        else
+          MatchableToken
+        end
+      end
+
       def filterable_fields
         @filterable_fields || DEFAULT_FILTERABLE_FIELDS
+      end
+
+      def range_fields
+        @range_fields || DEFAULT_RANGE_FIELDS
+      end
+
+      def hierarchal_fields
+        @hierarchal_fields || DEFAULT_HIERARCHAL_FIELDS
       end
     end
   end


### PR DESCRIPTION
In previous, fields parameters are passed through many many objects. This was done to let node objects utilize these parameters to build query hashes with their given token.

This commit introduces sub token classes and stops passing these parameters. Now each node objects simply ask the given token to build a hash.

I will add `DateToken` to support exact date matching filter in near future.