### PR TITLE
Introduce Qiita::Elasticsearch::Query class

### DIFF
--- a/lib/qiita/elasticsearch/query.rb
+++ b/lib/qiita/elasticsearch/query.rb
@@ -1,0 +1,29 @@
+require "qiita/elasticsearch/nodes/null_node"
+require "qiita/elasticsearch/nodes/or_separatable_node"
+require "qiita/elasticsearch/tokenizer"
+
+module Qiita
+  module Elasticsearch
+    class Query
+      # @param [Array<Qiita::Elasticsearch::Token>] tokens
+      def initialize(tokens)
+        @tokens = tokens
+      end
+
+      # @return [Hash]
+      def to_hash
+        if has_empty_tokens?
+          Nodes::NullNode.new.to_hash
+        else
+          Nodes::OrSeparatableNode.new(@tokens).to_hash
+        end
+      end
+
+      private
+
+      def has_empty_tokens?
+        @tokens.size.zero?
+      end
+    end
+  end
+end

--- a/lib/qiita/elasticsearch/query.rb
+++ b/lib/qiita/elasticsearch/query.rb
@@ -6,11 +6,43 @@ module Qiita
   module Elasticsearch
     class Query
       # @param [Array<Qiita::Elasticsearch::Token>] tokens
-      def initialize(tokens)
+      # @param [Hash] query_builder_options For building new query from this query
+      def initialize(tokens, query_builder_options = nil)
+        @query_builder_options = query_builder_options
         @tokens = tokens
       end
 
+      # @param [String] field_name
+      # @param [String] term
+      # @return [Qiita::Elasticsearch::Query]
+      # @example query.append_field_token(field_name: "tag", term: "Ruby")
+      def append_field_token(field_name: nil, term: nil)
+        build_query([*@tokens, "#{field_name}:#{term}"].join(" "))
+      end
+
+      # @param [String] field_name
+      # @param [String] term
+      # @return [Qiita::Elasticsearch::Query]
+      # @example query.delete_field_token(field_name: "tag", term: "Ruby")
+      def delete_field_token(field_name: nil, term: nil)
+        build_query(
+          @tokens.reject do |token|
+            token.field_name == field_name && token.term == term
+          end.join(" ")
+        )
+      end
+
+      # @param [String] field_name
+      # @param [String] term
+      # @example query.has_field_token?(field_name: "tag", term: "Ruby")
+      def has_field_token?(field_name: nil, term: nil)
+        @tokens.any? do |token|
+          token.field_name == field_name && token.term == term
+        end
+      end
+
       # @return [Hash]
+      # @example query.to_hash
       def to_hash
         if has_empty_tokens?
           Nodes::NullNode.new.to_hash
@@ -19,10 +51,40 @@ module Qiita
         end
       end
 
+      # @param [String] field_name
+      # @param [String] term
+      # @return [Qiita::Elasticsearch::Query]
+      # @example query.update_field_token(field_name: "tag", term: "Ruby")
+      def update_field_token(field_name: nil, term: nil)
+        build_query(
+          @tokens.reject do |token|
+            token.field_name == field_name
+          end.map(&:to_s).push("#{field_name}:#{term}").join(" ")
+        )
+      end
+
       private
+
+      # Build a new query from query string
+      # @param [String] query_string
+      # @return [Qiita::Elasticsearch::Query]
+      # @example build_query("test tag:Ruby")
+      def build_query(query_string)
+        query_builder.build(query_string)
+      end
 
       def has_empty_tokens?
         @tokens.size.zero?
+      end
+
+      # @return [Qiita::Elasticsearch::QueryBuilder]
+      def query_builder
+        QueryBuilder.new(query_builder_options)
+      end
+
+      # @return [Hash]
+      def query_builder_options
+        @query_builder_options || {}
       end
     end
   end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -25,7 +25,15 @@ module Qiita
       # @param [String] query_string Raw query string
       # @return [Qiita::Elasticsearch::Query]
       def build(query_string)
-        Query.new(tokenizer.tokenize(query_string))
+        Query.new(
+          tokenizer.tokenize(query_string),
+          downcased_fields: @downcased_fields,
+          filterable_fields: @filterable_fields,
+          hierarchal_fields: @hierarchal_fields,
+          int_fields: @int_fields,
+          matchable_fields: @matchable_fields,
+          time_zone: @time_zone,
+        )
       end
 
       private

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -1,6 +1,6 @@
 require "qiita/elasticsearch/nodes/null_node"
 require "qiita/elasticsearch/nodes/or_separatable_node"
-require "qiita/elasticsearch/tokenizer"
+require "qiita/elasticsearch/query"
 
 module Qiita
   module Elasticsearch
@@ -23,14 +23,9 @@ module Qiita
       end
 
       # @param [String] query_string Raw query string
-      # @return [Hash]
+      # @return [Qiita::Elasticsearch::Query]
       def build(query_string)
-        tokens = tokenizer.tokenize(query_string)
-        if tokens.size.zero?
-          Nodes::NullNode.new.to_hash
-        else
-          Nodes::OrSeparatableNode.new(tokens).to_hash
-        end
+        Query.new(tokenizer.tokenize(query_string))
       end
 
       private

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -3,7 +3,7 @@ require "qiita/elasticsearch/query_builder"
 RSpec.describe Qiita::Elasticsearch::QueryBuilder do
   describe "#build" do
     subject do
-      query_builder.build(query_string)
+      query_builder.build(query_string).to_hash
     end
 
     let(:downcased_fields) do
@@ -65,7 +65,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
 
       it "returns null query" do
-        is_expected.to eq query_builder.build("")
+        is_expected.to eq query_builder.build("").to_hash
       end
     end
 
@@ -460,7 +460,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
 
       it "returns null query" do
-        is_expected.to eq query_builder.build("")
+        is_expected.to eq query_builder.build("").to_hash
       end
     end
 
@@ -470,7 +470,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
 
       it "returns same query without OR token" do
-        is_expected.to eq query_builder.build("a")
+        is_expected.to eq query_builder.build("a").to_hash
       end
     end
 
@@ -480,7 +480,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
 
       it "treats both or and OR as OR token" do
-        is_expected.to eq query_builder.build("a OR b")
+        is_expected.to eq query_builder.build("a OR b").to_hash
       end
     end
 

--- a/spec/qiita/elasticsearch/query_spec.rb
+++ b/spec/qiita/elasticsearch/query_spec.rb
@@ -1,0 +1,121 @@
+require "qiita/elasticsearch/query"
+
+RSpec.describe Qiita::Elasticsearch::Query do
+  let(:query) do
+    query_builder.build(query_string)
+  end
+
+  let(:query_builder) do
+    Qiita::Elasticsearch::QueryBuilder.new(filterable_fields: ["tag"])
+  end
+
+  let(:query_string) do
+    "test tag:Rails"
+  end
+
+  describe "#append_field_token" do
+    subject do
+      query.append_field_token(field_name: "tag", term: "Ruby").to_hash
+    end
+
+    it "appends given field token and returns a new query" do
+      is_expected.to eq(
+        "filtered" => {
+          "filter" => {
+            "bool" => {
+              "_cache" => true,
+              "must" => [
+                {
+                  "term" => {
+                    "tag" => "Rails",
+                  },
+                },
+                {
+                  "term" => {
+                    "tag" => "Ruby",
+                  },
+                },
+              ],
+            },
+          },
+          "query" => {
+            "match" => {
+              "_all" => "test",
+            },
+          },
+        },
+      )
+    end
+  end
+
+  describe "#delete_field_token" do
+    subject do
+      query.delete_field_token(field_name: "tag", term: "Rails").to_hash
+    end
+
+    it "deletes given field token and returns a new query" do
+      is_expected.to eq(
+        "match" => {
+          "_all" => "test",
+        },
+      )
+    end
+  end
+
+  describe "#has_field_token?" do
+    subject do
+      query.has_field_token?(field_name: field_name, term: term)
+    end
+
+    let(:field_name) do
+      "tag"
+    end
+
+    let(:term) do
+      "Rails"
+    end
+
+    context "with same field name and term" do
+      it { is_expected.to be true }
+    end
+
+    context "with different field name" do
+      let(:field_name) do
+        "user"
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with different term" do
+      let(:field_name) do
+        "Ruby"
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#update_field_token" do
+    subject do
+      query.update_field_token(field_name: "tag", term: "Ruby").to_hash
+    end
+
+    it "updates field tokens that match with given field name and term" do
+      is_expected.to eq(
+        "filtered" => {
+          "filter" => {
+            "term" => {
+              "tag" => "Ruby",
+            },
+          },
+          "query" => {
+            "match" => {
+              "_all" => "test",
+            },
+          },
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
For more expressivity than raw Hash object. It's instance responds to `.to_hash` so we can use it as in the past, while some strict tests may fail.