### PR TITLE
Combine phrase and best_fields queries for unquoted matchable token

### DIFF
--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -80,10 +80,27 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         "a"
       end
 
-      it "returns match query" do
+      it "returns bool query including match and term queries" do
         expect(query.query.to_hash).to eq(
-          "match" => {
-            "_all" => "a",
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => ["_all"],
+                  "query" => "a",
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => ["_all"],
+                  "query" => "a",
+                  "type" => "best_fields",
+                },
+              },
+            ],
           },
         )
       end
@@ -96,8 +113,11 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       it "returns match_phrase query" do
         expect(query.query.to_hash).to eq(
-          "match_phrase" => {
-            "_all" => "a b",
+          "multi_match" => {
+            "boost" => 1,
+            "fields" => ["_all"],
+            "query" => "a b",
+            "type" => "phrase",
           },
         )
       end
@@ -117,8 +137,11 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
                 "must_not" => [
                   {
                     "query" => {
-                      "match_phrase" => {
-                        "_all" => "a b",
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "a b",
+                        "type" => "phrase",
                       },
                     },
                   },
@@ -142,6 +165,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       it "returns multi match query with phrase type" do
         expect(query.query.to_hash).to eq(
           "multi_match" => {
+            "boost" => 1,
             "fields" => matchable_fields,
             "query" => "a b",
             "type" => "phrase",
@@ -163,8 +187,25 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
                 "_cache" => true,
                 "must_not" => [
                   "query" => {
-                    "match" => {
-                      "_all" => "a",
+                    "bool" => {
+                      "should" => [
+                        {
+                          "multi_match" => {
+                            "boost" => 1,
+                            "fields" => ["_all"],
+                            "query" => "a",
+                            "type" => "phrase",
+                          },
+                        },
+                        {
+                          "multi_match" => {
+                            "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                            "fields" => ["_all"],
+                            "query" => "a",
+                            "type" => "best_fields",
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -185,13 +226,47 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
           "bool" => {
             "must" => [
               {
-                "match" => {
-                  "_all" => "a",
+                "bool" => {
+                  "should" => [
+                    {
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "a",
+                        "type" => "phrase",
+                      },
+                    },
+                    {
+                      "multi_match" => {
+                        "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                        "fields" => ["_all"],
+                        "query" => "a",
+                        "type" => "best_fields",
+                      },
+                    },
+                  ],
                 },
               },
               {
-                "match" => {
-                  "_all" => "b",
+                "bool" => {
+                  "should" => [
+                    {
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "b",
+                        "type" => "phrase",
+                      },
+                    },
+                    {
+                      "multi_match" => {
+                        "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                        "fields" => ["_all"],
+                        "query" => "b",
+                        "type" => "best_fields",
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -213,16 +288,50 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
                 "_cache" => true,
                 "must_not" => [
                   "query" => {
-                    "match" => {
-                      "_all" => "b",
+                    "bool" => {
+                      "should" => [
+                        {
+                          "multi_match" => {
+                            "boost" => 1,
+                            "fields" => ["_all"],
+                            "query" => "b",
+                            "type" => "phrase",
+                          },
+                        },
+                        {
+                          "multi_match" => {
+                            "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                            "fields" => ["_all"],
+                            "query" => "b",
+                            "type" => "best_fields",
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
               },
             },
             "query" => {
-              "match" => {
-                "_all" => "a",
+              "bool" => {
+                "should" => [
+                  {
+                    "multi_match" => {
+                      "boost" => 1,
+                      "fields" => ["_all"],
+                      "query" => "a",
+                      "type" => "phrase",
+                    },
+                  },
+                  {
+                    "multi_match" => {
+                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                      "fields" => ["_all"],
+                      "query" => "a",
+                      "type" => "best_fields",
+                    },
+                  },
+                ],
               },
             },
           },
@@ -239,11 +348,27 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         "a"
       end
 
-      it "returns multi_match query" do
+      it "returns multi_match query with phrase type" do
         expect(query.query.to_hash).to eq(
-          "multi_match" => {
-            "fields" => matchable_fields,
-            "query" => "a",
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => matchable_fields,
+                  "query" => "a",
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => matchable_fields,
+                  "query" => "a",
+                  "type" => "best_fields",
+                },
+              },
+            ],
           },
         )
       end
@@ -364,8 +489,25 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       it "returns match query" do
         expect(query.query.to_hash).to eq(
-          "match" => {
-            "_all" => 'tag\:a',
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => ["_all"],
+                  "query" => 'tag\:a',
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => ["_all"],
+                  "query" => 'tag\:a',
+                  "type" => "best_fields",
+                },
+              },
+            ],
           },
         )
       end
@@ -378,8 +520,25 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       it "returns match query" do
         expect(query.query.to_hash).to eq(
-          "match" => {
-            "_all" => "tag:a",
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => ["_all"],
+                  "query" => "tag:a",
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => ["_all"],
+                  "query" => "tag:a",
+                  "type" => "best_fields",
+                },
+              },
+            ],
           },
         )
       end
@@ -432,8 +591,25 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
               },
             },
             "query" => {
-              "match" => {
-                "_all" => "a",
+              "bool" => {
+                "should" => [
+                  {
+                    "multi_match" => {
+                      "boost" => 1,
+                      "fields" => ["_all"],
+                      "query" => "a",
+                      "type" => "phrase",
+                    },
+                  },
+                  {
+                    "multi_match" => {
+                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                      "fields" => ["_all"],
+                      "query" => "a",
+                      "type" => "best_fields",
+                    },
+                  },
+                ],
               },
             },
           },
@@ -451,13 +627,47 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
           "bool" => {
             "should" => [
               {
-                "match" => {
-                  "_all" => "a",
+                "bool" => {
+                  "should" => [
+                    {
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "a",
+                        "type" => "phrase",
+                      },
+                    },
+                    {
+                      "multi_match" => {
+                        "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                        "fields" => ["_all"],
+                        "query" => "a",
+                        "type" => "best_fields",
+                      },
+                    },
+                  ],
                 },
               },
               {
-                "match" => {
-                  "_all" => "b",
+                "bool" => {
+                  "should" => [
+                    {
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "b",
+                        "type" => "phrase",
+                      },
+                    },
+                    {
+                      "multi_match" => {
+                        "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                        "fields" => ["_all"],
+                        "query" => "b",
+                        "type" => "best_fields",
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -720,8 +930,25 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
                 },
               },
               {
-                "match" => {
-                  "_all" => "Ruby",
+                "bool" => {
+                  "should" => [
+                    {
+                      "multi_match" => {
+                        "boost" => 1,
+                        "fields" => ["_all"],
+                        "query" => "Ruby",
+                        "type" => "phrase",
+                      },
+                    },
+                    {
+                      "multi_match" => {
+                        "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                        "fields" => ["_all"],
+                        "query" => "Ruby",
+                        "type" => "best_fields",
+                      },
+                    },
+                  ],
                 },
               },
             ],

--- a/spec/qiita/elasticsearch/query_spec.rb
+++ b/spec/qiita/elasticsearch/query_spec.rb
@@ -1,6 +1,8 @@
 require "qiita/elasticsearch/query"
 
 RSpec.describe Qiita::Elasticsearch::Query do
+  include Qiita::Elasticsearch::SpecHelper
+
   let(:query) do
     query_builder.build(query_string)
   end
@@ -39,28 +41,7 @@ RSpec.describe Qiita::Elasticsearch::Query do
                 ],
               },
             },
-            "query" => {
-              "bool" => {
-                "should" => [
-                  {
-                    "multi_match" => {
-                      "boost" => 1,
-                      "fields" => ["_all"],
-                      "query" => "test",
-                      "type" => "phrase",
-                    },
-                  },
-                  {
-                    "multi_match" => {
-                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
-                      "fields" => ["_all"],
-                      "query" => "test",
-                      "type" => "best_fields",
-                    },
-                  },
-                ],
-              },
-            },
+            "query" => build_combined_match_query(query: "test"),
           },
         },
         "sort" => [{ "created_at" => "desc" }, "_score"],
@@ -75,28 +56,7 @@ RSpec.describe Qiita::Elasticsearch::Query do
 
     it "deletes given field token and returns a new query" do
       is_expected.to eq(
-        "query" => {
-          "bool" => {
-            "should" => [
-              {
-                "multi_match" => {
-                  "boost" => 1,
-                  "fields" => ["_all"],
-                  "query" => "test",
-                  "type" => "phrase",
-                },
-              },
-              {
-                "multi_match" => {
-                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
-                  "fields" => ["_all"],
-                  "query" => "test",
-                  "type" => "best_fields",
-                },
-              },
-            ],
-          },
-        },
+        "query" => build_combined_match_query(query: "test"),
         "sort" => [{ "created_at" => "desc" }, "_score"],
       )
     end
@@ -296,28 +256,7 @@ RSpec.describe Qiita::Elasticsearch::Query do
                 "tag" => "Ruby",
               },
             },
-            "query" => {
-              "bool" => {
-                "should" => [
-                  {
-                    "multi_match" => {
-                      "boost" => 1,
-                      "fields" => ["_all"],
-                      "query" => "test",
-                      "type" => "phrase",
-                    },
-                  },
-                  {
-                    "multi_match" => {
-                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
-                      "fields" => ["_all"],
-                      "query" => "test",
-                      "type" => "best_fields",
-                    },
-                  },
-                ],
-              },
-            },
+            "query" => build_combined_match_query(query: "test"),
           },
         },
         "sort" => [{ "created_at" => "desc" }, "_score"],

--- a/spec/qiita/elasticsearch/query_spec.rb
+++ b/spec/qiita/elasticsearch/query_spec.rb
@@ -40,8 +40,25 @@ RSpec.describe Qiita::Elasticsearch::Query do
               },
             },
             "query" => {
-              "match" => {
-                "_all" => "test",
+              "bool" => {
+                "should" => [
+                  {
+                    "multi_match" => {
+                      "boost" => 1,
+                      "fields" => ["_all"],
+                      "query" => "test",
+                      "type" => "phrase",
+                    },
+                  },
+                  {
+                    "multi_match" => {
+                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                      "fields" => ["_all"],
+                      "query" => "test",
+                      "type" => "best_fields",
+                    },
+                  },
+                ],
               },
             },
           },
@@ -59,8 +76,25 @@ RSpec.describe Qiita::Elasticsearch::Query do
     it "deletes given field token and returns a new query" do
       is_expected.to eq(
         "query" => {
-          "match" => {
-            "_all" => "test",
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => ["_all"],
+                  "query" => "test",
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => ["_all"],
+                  "query" => "test",
+                  "type" => "best_fields",
+                },
+              },
+            ],
           },
         },
         "sort" => [{ "created_at" => "desc" }, "_score"],
@@ -263,8 +297,25 @@ RSpec.describe Qiita::Elasticsearch::Query do
               },
             },
             "query" => {
-              "match" => {
-                "_all" => "test",
+              "bool" => {
+                "should" => [
+                  {
+                    "multi_match" => {
+                      "boost" => 1,
+                      "fields" => ["_all"],
+                      "query" => "test",
+                      "type" => "phrase",
+                    },
+                  },
+                  {
+                    "multi_match" => {
+                      "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                      "fields" => ["_all"],
+                      "query" => "test",
+                      "type" => "best_fields",
+                    },
+                  },
+                ],
               },
             },
           },

--- a/spec/qiita/elasticsearch/spec_helper.rb
+++ b/spec/qiita/elasticsearch/spec_helper.rb
@@ -1,0 +1,31 @@
+module Qiita
+  module Elasticsearch
+    module SpecHelper
+      # @return [Hash]
+      def build_combined_match_query(fields: ["_all"], query: nil)
+        {
+          "bool" => {
+            "should" => [
+              {
+                "multi_match" => {
+                  "boost" => 1,
+                  "fields" => fields,
+                  "query" => query,
+                  "type" => "phrase",
+                },
+              },
+              {
+                "multi_match" => {
+                  "boost" => Qiita::Elasticsearch::MatchableToken::RELATIVE_BEST_FIELDS_QUERY_WEIGHT,
+                  "fields" => fields,
+                  "query" => query,
+                  "type" => "best_fields",
+                },
+              },
+            ]
+          },
+        }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ if ENV["CI"]
   CodeClimate::TestReporter.start
 end
 
+require File.expand_path("../qiita/elasticsearch/spec_helper", __FILE__)
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
完全一致した文書がなかなか上位に来ないという問題に対処するために、クエリを連続して含む記事により高いスコアを付与するように変更しました。

review plz @r7kamura 

### 変更点

これまでは `"` で囲まれていないクエリには "best_fields" matchクエリをだけを使っていましたが、"phrase" と "best_fields" matchクエリを合わせたクエリを使うようにしました。

#### 動作例

あるインデックスに"電話番号"というクエリを投げたとき、masterとboost-phrase-matchingブランチはそれぞれ同じ順番でドキュメントを返します:

![image](https://cloud.githubusercontent.com/assets/96157/8404054/f2792c9c-1e84-11e5-857a-a4ecf21dcc7e.png)

しかし、Elasticsearchが返すスコアは全く異なります:

```
# master
0.44672415
0.3062868
0.27920258
0.1515718
0.10450438

# boost-phrase-matching
0.7445402
0.051047802
0.046533763
0.025261965
0.017417395
```

boost-phrase-matchingでは連続した表現により大きなスコアが割り当てられるのでクエリに合致した記事がより高確率で高いスコアを獲得することが期待されます。