### PR TITLE
Use `match` query for non-filterable `field:value` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ query_builder.build("a OR b")
 #=> {"bool"=>{"should"=>[{"match"=>{"_all"=>"a"}}, {"match"=>{"_all"=>"b"}}]}}
 ```
 
-### matchable_fields
-Pass `:matchable_fields` option to tell matchable field names (default: `_all`).
+### default_fields
+Pass `:default_fields` option to tell default (matchable) field names (default: `_all`).
 
 ```rb
-query_builder = Qiita::Elasticsearch::QueryBuilder.new(matchable_fields: ["body", "title"])
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(default_fields: ["body", "title"])
 
 query_builder.build("a")
 #=> {"multi_match"=>{"fields"=>["body", "title"], "query"=>"a"}}

--- a/lib/qiita/elasticsearch/matchable_token.rb
+++ b/lib/qiita/elasticsearch/matchable_token.rb
@@ -5,7 +5,7 @@ module Qiita
     class MatchableToken < Token
       RELATIVE_BEST_FIELDS_QUERY_WEIGHT = 0.5
 
-      attr_writer :matchable_fields
+      attr_writer :default_fields
 
       # @return [Hash]
       def to_hash
@@ -40,8 +40,8 @@ module Qiita
       def matchable_fields
         if field_name
           [field_name]
-        elsif @matchable_fields && !@matchable_fields.empty?
-          @matchable_fields
+        elsif @default_fields && !@default_fields.empty?
+          @default_fields
         else
           ["_all"]
         end

--- a/lib/qiita/elasticsearch/matchable_token.rb
+++ b/lib/qiita/elasticsearch/matchable_token.rb
@@ -38,7 +38,9 @@ module Qiita
       end
 
       def matchable_fields
-        if @matchable_fields && !@matchable_fields.empty?
+        if field_name
+          [field_name]
+        elsif @matchable_fields && !@matchable_fields.empty?
           @matchable_fields
         else
           ["_all"]

--- a/lib/qiita/elasticsearch/matchable_token.rb
+++ b/lib/qiita/elasticsearch/matchable_token.rb
@@ -30,11 +30,19 @@ module Qiita
         {
           "multi_match" => {
             "boost" => boost,
-            "fields" => @matchable_fields || ["_all"],
+            "fields" => matchable_fields,
             "query" => @term,
             "type" => type,
           },
         }
+      end
+
+      def matchable_fields
+        if @matchable_fields && !@matchable_fields.empty?
+          @matchable_fields
+        else
+          ["_all"]
+        end
       end
     end
   end

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -5,6 +5,7 @@ require "qiita/elasticsearch/query"
 module Qiita
   module Elasticsearch
     class QueryBuilder
+      # @param [Array<String>, nil] all_fields
       # @param [Array<String>, nil] date_fields
       # @param [Array<String>, nil] downcased_fields
       # @param [Array<String>, nil] filterable_fields
@@ -12,7 +13,8 @@ module Qiita
       # @param [Array<String>, nil] int_fields
       # @param [Array<String>, nil] matchable_fields
       # @param [String, nil] time_zone
-      def initialize(date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
+      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
+        @all_fields = all_fields
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
@@ -40,6 +42,7 @@ module Qiita
 
       def tokenizer
         @tokenizer ||= Tokenizer.new(
+          all_fields: @all_fields,
           date_fields: @date_fields,
           downcased_fields: @downcased_fields,
           filterable_fields: @filterable_fields,

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -11,16 +11,16 @@ module Qiita
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] int_fields
-      # @param [Array<String>, nil] matchable_fields
+      # @param [Array<String>, nil] default_fields
       # @param [String, nil] time_zone
-      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
+      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, default_fields: nil, time_zone: nil)
         @all_fields = all_fields
         @date_fields = date_fields
         @downcased_fields = downcased_fields
         @filterable_fields = filterable_fields
         @hierarchal_fields = hierarchal_fields
         @int_fields = int_fields
-        @matchable_fields = matchable_fields
+        @default_fields = default_fields
         @time_zone = time_zone
       end
 
@@ -33,7 +33,7 @@ module Qiita
           filterable_fields: @filterable_fields,
           hierarchal_fields: @hierarchal_fields,
           int_fields: @int_fields,
-          matchable_fields: @matchable_fields,
+          default_fields: @default_fields,
           time_zone: @time_zone,
         )
       end
@@ -48,7 +48,7 @@ module Qiita
           filterable_fields: @filterable_fields,
           hierarchal_fields: @hierarchal_fields,
           int_fields: @int_fields,
-          matchable_fields: @matchable_fields,
+          default_fields: @default_fields,
           time_zone: @time_zone,
         )
       end

--- a/lib/qiita/elasticsearch/token.rb
+++ b/lib/qiita/elasticsearch/token.rb
@@ -15,8 +15,8 @@ module Qiita
 
       # @param [true, false] downcased True if given term must be downcased on query representation
       # @param [String, nil] field_name Field name part
-      # @param [true, fales] negative True if this term represents negative token (e.g. "-Perl")
-      # @param [true, false] quoted Given term is quoted or note
+      # @param [true, false] negative True if this term represents negative token (e.g. "-Perl")
+      # @param [true, false] quoted Given term is quoted or not
       # @param [true, false] filter True if this term should be used as filter
       # @param [String] term Term part
       # @param [String] token_string Original entire string

--- a/lib/qiita/elasticsearch/token.rb
+++ b/lib/qiita/elasticsearch/token.rb
@@ -17,13 +17,15 @@ module Qiita
       # @param [String, nil] field_name Field name part
       # @param [true, fales] negative True if this term represents negative token (e.g. "-Perl")
       # @param [true, false] quoted Given term is quoted or note
+      # @param [true, false] filter True if this term should be used as filter
       # @param [String] term Term part
       # @param [String] token_string Original entire string
-      def initialize(downcased: nil, field_name: nil, negative: nil, quoted: nil, term: nil, token_string: nil)
+      def initialize(downcased: nil, field_name: nil, negative: nil, quoted: nil, filter: nil, term: nil, token_string: nil)
         @downcased = downcased
         @field_name = field_name
         @negative = negative
         @quoted = quoted
+        @filter = filter
         @term = term
         @token_string = token_string
       end
@@ -38,7 +40,7 @@ module Qiita
       end
 
       def filter?
-        !field_name.nil? || negative?
+        !!@filter || negative?
       end
 
       # @return [true, false] True if this token is for query

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -12,7 +12,7 @@ module Qiita
       DEFAULT_FILTERABLE_FIELDS = []
       DEFAULT_HIERARCHAL_FIELDS = []
       DEFAULT_INT_FIELDS = []
-      DEFAULT_MATCHABLE_FIELDS = []
+      DEFAULT_DEFAULT_FIELDS = []
       EXTRA_DATE_FIELDS = %w(created updated)
       EXTRA_FILTERABLE_FIELDS = %w(created is sort updated)
 
@@ -34,15 +34,15 @@ module Qiita
       # @param [Array<String>, nil] filterable_fields
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] int_fields
-      # @param [Array<String>, nil] matchable_fields
+      # @param [Array<String>, nil] default_fields
       # @param [String, nil] time_zone
-      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, int_fields: nil, matchable_fields: nil, time_zone: nil)
+      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, filterable_fields: nil, hierarchal_fields: nil, int_fields: nil, default_fields: nil, time_zone: nil)
         @date_fields = (date_fields || DEFAULT_DATE_FIELDS) | EXTRA_DATE_FIELDS
         @downcased_fields = downcased_fields || DEFAULT_DOWNCASED_FIELDS
         @filterable_fields = (filterable_fields || DEFAULT_FILTERABLE_FIELDS) | EXTRA_FILTERABLE_FIELDS
         @hierarchal_fields = hierarchal_fields || DEFAULT_HIERARCHAL_FIELDS
         @int_fields = int_fields || DEFAULT_INT_FIELDS
-        @matchable_fields = matchable_fields || DEFAULT_MATCHABLE_FIELDS
+        @default_fields = default_fields || DEFAULT_DEFAULT_FIELDS
         @all_fields = aggregate_all_fields(all_fields)
         @time_zone = time_zone
       end
@@ -65,7 +65,7 @@ module Qiita
             term: term,
             token_string: token_string,
           )
-          token.matchable_fields = @matchable_fields if token.is_a?(MatchableToken)
+          token.default_fields = @default_fields if token.is_a?(MatchableToken)
           token.time_zone = @time_zone if token.is_a?(DateToken)
           token
         end
@@ -81,7 +81,7 @@ module Qiita
           @filterable_fields,
           @hierarchal_fields,
           @int_fields,
-          @matchable_fields
+          @default_fields
         ].flatten.compact
 
         fields.map { |field| field.sub(/\^\d+\z/, "") }.uniq

--- a/lib/qiita/elasticsearch/tokenizer.rb
+++ b/lib/qiita/elasticsearch/tokenizer.rb
@@ -12,6 +12,7 @@ module Qiita
       DEFAULT_FILTERABLE_FIELDS = []
       DEFAULT_HIERARCHAL_FIELDS = []
       DEFAULT_INT_FIELDS = []
+      DEFAULT_MATCHABLE_FIELDS = []
       EXTRA_DATE_FIELDS = %w(created updated)
       EXTRA_FILTERABLE_FIELDS = %w(created is sort updated)
 
@@ -40,7 +41,7 @@ module Qiita
         @filterable_fields = (filterable_fields || DEFAULT_FILTERABLE_FIELDS) | EXTRA_FILTERABLE_FIELDS
         @hierarchal_fields = hierarchal_fields || DEFAULT_HIERARCHAL_FIELDS
         @int_fields = int_fields || DEFAULT_INT_FIELDS
-        @matchable_fields = matchable_fields
+        @matchable_fields = matchable_fields || DEFAULT_MATCHABLE_FIELDS
         @time_zone = time_zone
       end
 

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
     let(:hierarchal_fields) do
     end
 
-    let(:matchable_fields) do
+    let(:default_fields) do
     end
 
     let(:int_fields) do
@@ -34,7 +34,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         downcased_fields: downcased_fields,
         filterable_fields: filterable_fields,
         hierarchal_fields: hierarchal_fields,
-        matchable_fields: matchable_fields,
+        default_fields: default_fields,
         int_fields: int_fields,
         date_fields: date_fields,
         time_zone: time_zone,
@@ -138,8 +138,8 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
     end
 
-    context "with double-quoted token with matchable field names" do
-      let(:matchable_fields) do
+    context "with double-quoted token with default field names" do
+      let(:default_fields) do
         ["title"]
       end
 
@@ -151,7 +151,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         expect(query.query.to_hash).to eq(
           "multi_match" => {
             "boost" => 1,
-            "fields" => matchable_fields,
+            "fields" => default_fields,
             "query" => "a b",
             "type" => "phrase",
           },
@@ -219,8 +219,8 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
     end
 
-    context "with matchable_fields property" do
-      let(:matchable_fields) do
+    context "with default_fields property" do
+      let(:default_fields) do
         ["tag"]
       end
 
@@ -229,7 +229,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
 
       it "returns multi_match query with phrase type" do
-        expect(query.query.to_hash).to eq(build_combined_match_query(fields: matchable_fields, query: "a"))
+        expect(query.query.to_hash).to eq(build_combined_match_query(fields: default_fields, query: "a"))
       end
     end
 

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       end
     end
 
-    context "with fields property" do
+    context "with matchable_fields property" do
       let(:matchable_fields) do
         ["tag"]
       end

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
   include Qiita::Elasticsearch::SpecHelper
 
   describe "#build" do
+    let(:all_fields) do
+    end
+
     let(:downcased_fields) do
     end
 
@@ -27,6 +30,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
     let(:properties) do
       {
+        all_fields: all_fields,
         downcased_fields: downcased_fields,
         filterable_fields: filterable_fields,
         hierarchal_fields: hierarchal_fields,
@@ -248,6 +252,20 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
             },
           },
         )
+      end
+    end
+
+    context "with token including non-filterable field name" do
+      let(:all_fields) do
+        ["title"]
+      end
+
+      let(:query_string) do
+        "title:foo"
+      end
+
+      it "returns match query for the field" do
+        expect(query.query.to_hash).to eq(build_combined_match_query(fields: ["title"], query: "foo"))
       end
     end
 


### PR DESCRIPTION
Previously we've treated all `field:value` input as filter and always issued `term` filter. However, when user inputted `field:value` for an _analyzed_ field, the `term` filter sometimes does not match the desired document. With this change, the `field:value` input for analyzed field issues `match` query.

* Added `all_fields` parameter to some classes to distinguish `field:value` input and non-field input including a `:`.
* Handle non-filterable `field:value` input as MatchableToken.
* Added `filter` parameter to Token because we can no longer know whether it's a filter token or not depending on whether the user specified a field name or not.