### PR TITLE
Fix error occurred while bundling (installing activesupport) in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.0.0
+- 2.3.1
 env:
   global:
     secure: f904YN7iTQRLl9mDSpRat+D5/JlFmdkL+3eXP1J8fsGV2jIdcSRc/RraAryra8trhGg69nGRsWhvwI4NLW2TgnUV8FU+474JRiAOS7sPvusCW6SdTBV5k1bW1cSFlBdtmvs9v8ew0WCptSXoZU5Ew6gEmHW+2YpUAbIvNqrC8oA=


### PR DESCRIPTION
## Why
Gem::InstallError: activesupport(5.0.0) requires Ruby version >= 2.2.2

## Do
Change ruby version to 2.3.1 on travis CI (Update .travis.yml)
