### PR TITLE
Add default_sorts option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ query_builder.build("a")
 #=> {"multi_match"=>{"fields"=>["body", "title"], "query"=>"a"}}
 ```
 
+### default_sorts
+Pass `:default_sorts` option to tell default sort orders (default: `[{ "created_at" => "desc" }, "_score"]`).
+
+```rb
+query_builder = Qiita::Elasticsearch::QueryBuilder.new(default_sorts: [{ "_score" => "desc" }])
+
+query_builder.build("a")
+#=> {"match"=>{"_all"=>"a"}, "sort"=>[{"_score"=>"desc"}]}
+```
+
 ### filterable_fields
 Pass `:filterable_fields` option to enable filtered queries like `tag:Ruby`.
 

--- a/lib/qiita/elasticsearch/query.rb
+++ b/lib/qiita/elasticsearch/query.rb
@@ -70,7 +70,7 @@ module Qiita
 
       # @return [Array] sort property for request body for Elasticsearch
       def sort
-        SORTS_TABLE[sort_term] || DEFAULT_SORT
+        SORTS_TABLE[sort_term] || @query_builder_options[:default_sorts] || DEFAULT_SORT
       end
 
       def sort_term

--- a/lib/qiita/elasticsearch/query_builder.rb
+++ b/lib/qiita/elasticsearch/query_builder.rb
@@ -12,8 +12,9 @@ module Qiita
       # @param [Array<String>, nil] hierarchal_fields
       # @param [Array<String>, nil] int_fields
       # @param [Array<String>, nil] default_fields
+      # @param [Array<String>, nil] default_sorts
       # @param [String, nil] time_zone
-      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, default_fields: nil, time_zone: nil)
+      def initialize(all_fields: nil, date_fields: nil, downcased_fields: nil, hierarchal_fields: nil, filterable_fields: nil, int_fields: nil, default_fields: nil, default_sorts: nil, time_zone: nil)
         @all_fields = all_fields
         @date_fields = date_fields
         @downcased_fields = downcased_fields
@@ -21,6 +22,7 @@ module Qiita
         @hierarchal_fields = hierarchal_fields
         @int_fields = int_fields
         @default_fields = default_fields
+        @default_sorts = default_sorts
         @time_zone = time_zone
       end
 
@@ -34,6 +36,7 @@ module Qiita
           hierarchal_fields: @hierarchal_fields,
           int_fields: @int_fields,
           default_fields: @default_fields,
+          default_sorts: @default_sorts,
           time_zone: @time_zone,
         )
       end

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
     let(:default_fields) do
     end
 
+    let(:default_sorts) do
+    end
+
     let(:int_fields) do
     end
 
@@ -35,6 +38,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         filterable_fields: filterable_fields,
         hierarchal_fields: hierarchal_fields,
         default_fields: default_fields,
+        default_sorts: default_sorts,
         int_fields: int_fields,
         date_fields: date_fields,
         time_zone: time_zone,
@@ -903,6 +907,41 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
       it "returns default sort option" do
         expect(query.sort).to eq([{ "created_at" => "desc" }, "_score"])
+      end
+    end
+
+    context "with default_sorts property" do
+      let(:default_sorts) do
+        [{ "_score" => "desc" }]
+      end
+
+      let(:query_string) do
+        "a"
+      end
+
+      it "returns a Query that has the specified sort default option" do
+        expect(query.sort).to eq([{ "_score" => "desc" }])
+      end
+    end
+
+    context "with default_sorts property and override sort:created-asc" do
+      let(:default_sorts) do
+        [{ "_score" => "desc" }]
+      end
+
+      let(:query_string) do
+        "sort:created-asc"
+      end
+
+      it "returns a Query overrided to sort in updated order" do
+        expect(query.sort).to eq(
+          [
+            {
+              "created_at" => "asc",
+            },
+            "_score",
+          ],
+        )
       end
     end
 


### PR DESCRIPTION
Default sort option `{ default_sort: [{ "field" => "asc/desc" }, ...] }` in QueryBuilder.new.
e.g.
```rb
query_builder = Qiita::Elasticsearch::QueryBuilder.new(default_sorts: [{ "_score" => "desc" }])

query_builder.build("a")
#=> {"match"=>{"_all"=>"a"}, "sort"=>[{"_score"=>"desc"}]}
```
Overridable with query string "sort:...".
e.g.
```rb
query_builder = Qiita::Elasticsearch::QueryBuilder.new(default_sorts: [{ "_score" => "desc" }])

query_builder.build("a sort:created-asc")
#=> {"match"=>{"_all"=>"a"}, "sort"=>[{"created_at" => "asc"}, "_score"]}
```
