### PR TITLE
Filtering with relative date ranges

### DIFF
--- a/lib/qiita/elasticsearch/concerns/range_operand_includable.rb
+++ b/lib/qiita/elasticsearch/concerns/range_operand_includable.rb
@@ -8,8 +8,6 @@ module Qiita
 
         RANGE_TERM_REGEXP = /\A(?<operand>\<=|\<|\>=|\>)(?<query>.*)\z/
 
-        private
-
         # @return [String, nil]
         # @example Suppose @term is "created_at:>=2015-04-16"
         #   range_parameter #=> "gte"
@@ -23,6 +21,8 @@ module Qiita
         def range_query
           range_match[:query]
         end
+
+        private
 
         def range_match
           @range_match ||= RANGE_TERM_REGEXP.match(@term) || {}

--- a/lib/qiita/elasticsearch/date_token.rb
+++ b/lib/qiita/elasticsearch/date_token.rb
@@ -8,54 +8,140 @@ module Qiita
     class DateToken < Token
       include Concerns::RangeOperandIncludable
 
-      # @note Matches to "YYYY", "YYYY-MM" and "YYYY-MM-DD"
-      DATE_PATTERN = /\A
-        (?<year>\d{4})
-        (?:
-          -
-          (?<month>\d{1,2})
+      attr_accessor :time_zone
+
+      class BaseDateExpression
+        FIELD_NAMES_TABLE = {
+          "created" => "created_at",
+          "updated" => "updated_at",
+        }
+
+        # @param [DateToken] token date token instance containing date expressions
+        def initialize(token)
+          @token = token
+        end
+
+        def match
+          @match ||= self.class::PATTERN.match(@token.range_query || @token.term)
+        end
+
+        def to_hash
+          fail NotImplementedError
+        end
+
+        # e.g. created:2000-01-01 -> created_at
+        # @return [String]
+        def converted_field_name
+          FIELD_NAMES_TABLE[@token.field_name] || @token.field_name
+        end
+      end
+
+      class AbsoluteDateExpression < BaseDateExpression
+        # @note Matches to "YYYY", "YYYY-MM" and "YYYY-MM-DD"
+        PATTERN = /\A
+          (?<year>\d{4})
           (?:
             -
-            (?<day>\d{1,2})
+            (?<month>\d{1,2})
+            (?:
+              -
+              (?<day>\d{1,2})
+            )?
           )?
-        )?
-      \z/x
+        \z/x
 
-      FIELD_NAMES_TABLE = {
-        "created" => "created_at",
-        "updated" => "updated_at",
-      }
+        def to_hash
+          if @token.range_parameter
+            range_block(@token.range_parameter => @token.range_query, "time_zone" => @token.time_zone)
+          else
+            range_block("gte" => beginning_of_range.to_s, "lt" => end_of_range.to_s, "time_zone" => @token.time_zone)
+          end
+        end
 
-      attr_writer :time_zone
+        private
 
-      # @return [Hash]
-      # @raise [InvalidQuery]
-      def to_hash
-        if date_match
-          if range_parameter
+        def range_block(field_block)
+          {
+            "range" => {
+              converted_field_name => field_block.reject do |key, value|
+                key == "time_zone" && value.nil?
+              end,
+            }
+          }
+        end
+
+        # @return [Date]
+        def end_of_range
+          @end_of_range ||=
+            case
+            when match[:day]
+              beginning_of_range + 1.day
+            when match[:month]
+              beginning_of_range + 1.month
+            else
+              beginning_of_range + 1.year
+            end
+        end
+
+        # @return [Date]
+        def beginning_of_range
+          @beginning_of_range ||=
+            case
+            when match[:day]
+              Date.new(match[:year].to_i, match[:month].to_i, match[:day].to_i)
+            when match[:month]
+              Date.new(match[:year].to_i, match[:month].to_i)
+            else
+              Date.new(match[:year].to_i)
+            end
+        end
+      end
+
+      class RelativeDateExpression < BaseDateExpression
+        # @note Matches to "30d" and "30days"
+        PATTERN = /\A
+          (?<digit>\d+)
+          (?<type>d|y|day|days|year|years)
+        \z/x
+
+        def to_hash
+          if @token.range_parameter
             {
               "range" => {
                 converted_field_name => {
-                  range_parameter => range_query,
-                  "time_zone" => @time_zone,
-                }.reject do |key, value|
-                  key == "time_zone" && value.nil?
-                end,
+                  @token.range_parameter => relative_range_with_hours,
+                },
               },
             }
           else
-            {
-              "range" => {
-                converted_field_name => {
-                  "gte" => beginning_of_range.to_s,
-                  "lt" => end_of_range.to_s,
-                  "time_zone" => @time_zone,
-                }.reject do |key, value|
-                  key == "time_zone" && value.nil?
-                end,
-              },
-            }
+            Nodes::NullNode.new.to_hash
           end
+        end
+
+        private
+
+        def relative_range_with_hours
+          @relative_range_with_hours ||=
+            "now-" + convert_to_hours.to_s + "h"
+        end
+
+        # @return [Integer]
+        def convert_to_hours
+          case match[:type]
+          when "d", "day", "days"
+            match[:digit].to_i * 24
+          when "y", "year", "years"
+            match[:digit].to_i * 24 * 365
+          else
+            fail NotImplementedError
+          end
+        end
+      end
+
+      # @return [Hash]
+      def to_hash
+        if date
+          date.to_hash
         else
           Nodes::NullNode.new.to_hash
         end
@@ -63,45 +149,22 @@ module Qiita
 
       private
 
-      # @return [Date]
-      def beginning_of_range
-        @beginning_of_range ||=
-          case
-          when date_match[:day]
-            Date.new(date_match[:year].to_i, date_match[:month].to_i, date_match[:day].to_i)
-          when date_match[:month]
-            Date.new(date_match[:year].to_i, date_match[:month].to_i)
-          else
-            Date.new(date_match[:year].to_i)
-          end
+      # @return [BaseDateExpression, nil]
+      def date
+        @date ||= select_date
       end
 
-      # e.g. created:2000-01-01 -> created_at
-      # @return [String]
-      def converted_field_name
-        FIELD_NAMES_TABLE[@field_name] || @field_name
-      end
-
-      def date_match
-        @date_match ||= DATE_PATTERN.match(range_query || @term)
-      end
-
-      # @return [Date]
-      def end_of_range
-        @end_of_range ||=
-          case
-          when date_match[:day]
-            beginning_of_range + 1.day
-          when date_match[:month]
-            beginning_of_range + 1.month
-          else
-            beginning_of_range + 1.year
-          end
+      def select_date
+        date = AbsoluteDateExpression.new(self)
+        return date if date.match
+        date = RelativeDateExpression.new(self)
+        return date if date.match
+        nil
       end
 
       # @note Override
       def has_invalid_term?
-        !!date_match
+        !date
       end
     end
   end

--- a/qiita-elasticsearch.gemspec
+++ b/qiita-elasticsearch.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler", ">= 1.7"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "rubocop", "0.29.1"

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -772,130 +772,166 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
     end
 
     context "with date field name" do
-      context "and no range operand" do
-        context "and query is YYYY" do
+      context "and absolute date expression" do
+        context "and no range operand" do
+          context "and query is YYYY" do
+            let(:query_string) do
+              "created:2015"
+            end
+
+            it "returns range filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "gte" => "2015-01-01",
+                        "lt" => "2016-01-01"
+                      }
+                    },
+                  },
+                },
+              )
+            end
+          end
+
+          context "and query is YYYY-MM" do
+            let(:query_string) do
+              "created:2015-04"
+            end
+
+            it "returns range filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "gte" => "2015-04-01",
+                        "lt" => "2015-05-01"
+                      }
+                    },
+                  },
+                },
+              )
+            end
+          end
+
+          context "and query is YYYY-MM-DD" do
+            let(:query_string) do
+              "created:2015-04-17"
+            end
+
+            it "returns range filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "gte" => "2015-04-17",
+                        "lt" => "2015-04-18"
+                      }
+                    },
+                  },
+                },
+              )
+            end
+          end
+
+          context "and time_zone" do
+            let(:time_zone) do
+              "+09:00"
+            end
+
+            let(:query_string) do
+              "created:2015-04-17"
+            end
+
+            it "returns range filter with time_zone" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "gte" => "2015-04-17",
+                        "lt" => "2015-04-18",
+                        "time_zone" => time_zone,
+                      }
+                    },
+                  },
+                },
+              )
+            end
+          end
+        end
+
+        context "and single operand" do
           let(:query_string) do
-            "created:2015"
+            "created:<2015-04"
           end
 
           it "returns range filter" do
-            expect(query.query.to_hash).to eq(
-              "filtered" => {
-                "filter" => {
-                  "range" => {
-                    "created_at" => {
-                      "gte" => "2015-01-01",
-                      "lt" => "2016-01-01"
-                    }
-                  },
-                },
-              },
-            )
-          end
-        end
-
-        context "and query is YYYY-MM" do
-          let(:query_string) do
-            "created:2015-04"
-          end
-
-          it "returns range filter" do
-            expect(query.query.to_hash).to eq(
-              "filtered" => {
-                "filter" => {
-                  "range" => {
-                    "created_at" => {
-                      "gte" => "2015-04-01",
-                      "lt" => "2015-05-01"
-                    }
-                  },
-                },
-              },
-            )
-          end
-        end
-
-        context "and query is YYYY-MM-DD" do
-          let(:query_string) do
-            "created:2015-04-17"
-          end
-
-          it "returns range filter" do
-            expect(query.query.to_hash).to eq(
-              "filtered" => {
-                "filter" => {
-                  "range" => {
-                    "created_at" => {
-                      "gte" => "2015-04-17",
-                      "lt" => "2015-04-18"
-                    }
-                  },
-                },
-              },
-            )
-          end
-        end
-
-        context "and time_zone" do
-          let(:time_zone) do
-            "+09:00"
-          end
-
-          let(:query_string) do
-            "created:2015-04-17"
-          end
-
-          it "returns range filter with time_zone" do
-            expect(query.query.to_hash).to eq(
-              "filtered" => {
-                "filter" => {
-                  "range" => {
-                    "created_at" => {
-                      "gte" => "2015-04-17",
-                      "lt" => "2015-04-18",
-                      "time_zone" => time_zone,
-                    }
-                  },
-                },
-              },
-            )
-          end
-        end
-      end
-
-      context "and single operand" do
-        let(:query_string) do
-          "created:<2015-04"
-        end
-
-        it "returns range filter" do
-          expect(query.query.to_hash).to eq(
-            "filtered" => {
-              "filter" => {
-                "range" => {
-                  "created_at" => {
-                    "lt" => "2015-04",
-                  },
-                },
-              },
-            },
-          )
-        end
-
-        context "and time_zone" do
-          let(:time_zone) do
-            "+09:00"
-          end
-
-          it "returns range filter with time_zone" do
             expect(query.query.to_hash).to eq(
               "filtered" => {
                 "filter" => {
                   "range" => {
                     "created_at" => {
                       "lt" => "2015-04",
-                      "time_zone" => time_zone,
                     },
+                  },
+                },
+              },
+            )
+          end
+
+          context "and time_zone" do
+            let(:time_zone) do
+              "+09:00"
+            end
+
+            it "returns range filter with time_zone" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "lt" => "2015-04",
+                        "time_zone" => time_zone,
+                      },
+                    },
+                  },
+                },
+              )
+            end
+          end
+        end
+
+        context "and multiple operands" do
+          let(:query_string) do
+            "created:>=2015-04-01 created:<=2015-04-17"
+          end
+
+          it "returns two range filters within bool filter" do
+            expect(query.query.to_hash).to eq(
+              "filtered" => {
+                "filter" => {
+                  "bool" => {
+                    "_cache" => true,
+                    "must" => [
+                      {
+                        "range" => {
+                          "created_at" => {
+                            "gte" => "2015-04-01",
+                          },
+                        },
+                      },
+                      {
+                        "range" => {
+                          "created_at" => {
+                            "lte" => "2015-04-17",
+                          },
+                        },
+                      },
+                    ],
                   },
                 },
               },
@@ -904,37 +940,217 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         end
       end
 
-      context "and multiple operands" do
-        let(:query_string) do
-          "created:>=2015-04-01 created:<=2015-04-17"
-        end
+      context "and relative date expression" do
+        context "and invalid type" do
+          let(:query_string) do
+            "created:1h"
+          end
 
-        it "returns two range filters within bool filter" do
-          expect(query.query.to_hash).to eq(
-            "filtered" => {
-              "filter" => {
-                "bool" => {
-                  "_cache" => true,
-                  "must" => [
-                    {
-                      "range" => {
-                        "created_at" => {
-                          "gte" => "2015-04-01",
-                        },
-                      },
+          it "returns null filtered query" do
+            expect(query.query.to_hash).to eq(
+              "filtered" => {
+                "filter" => {
+                  "query" => {
+                    "ids" => {
+                      "values" => [],
                     },
-                    {
-                      "range" => {
-                        "created_at" => {
-                          "lte" => "2015-04-17",
-                        },
-                      },
-                    },
-                  ],
+                  },
                 },
               },
-            },
-          )
+            )
+          end
+        end
+
+        context "and abbreviated type" do
+          context "and no range operand" do
+            let(:query_string) do
+              "created:1d"
+            end
+
+            it "returns null filtered query" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "query" => {
+                      "ids" => {
+                        "values" => [],
+                      },
+                    },
+                  },
+                },
+              )
+            end
+          end
+
+          context "and single operand" do
+            let(:query_string) do
+              "created:<2d"
+            end
+
+            it "returns range filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "lt" => "now-48h",
+                      },
+                    },
+                  },
+                },
+              )
+            end
+
+            context "and time_zone" do
+              let(:time_zone) do
+                "+09:00"
+              end
+
+              it "return query ignoring time_zone" do
+                expect(query.query.to_hash).to eq(
+                  "filtered" => {
+                    "filter" => {
+                      "range" => {
+                        "created_at" => {
+                          "lt" => "now-48h",
+                        },
+                      },
+                    },
+                  },
+                )
+              end
+            end
+          end
+
+          context "and multiple operands" do
+            let(:query_string) do
+              "created:>=2d created:<=1d"
+            end
+
+            it "returns two range filters within bool filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "bool" => {
+                      "_cache" => true,
+                      "must" => [
+                        {
+                          "range" => {
+                            "created_at" => {
+                              "gte" => "now-48h",
+                            },
+                          },
+                        },
+                        {
+                          "range" => {
+                            "created_at" => {
+                              "lte" => "now-24h",
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              )
+            end
+          end
+        end
+
+        context "and expanted type" do
+          context "and no range operand" do
+            let(:query_string) do
+              "created:1day"
+            end
+
+            it "returns null filtered query" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "query" => {
+                      "ids" => {
+                        "values" => [],
+                      },
+                    },
+                  },
+                },
+              )
+            end
+          end
+
+          context "and single operand" do
+            let(:query_string) do
+              "created:<2days"
+            end
+
+            it "returns range filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "range" => {
+                      "created_at" => {
+                        "lt" => "now-48h",
+                      },
+                    },
+                  },
+                },
+              )
+            end
+
+            context "and time_zone" do
+              let(:time_zone) do
+                "+09:00"
+              end
+
+              it "return query ignoring time_zone" do
+                expect(query.query.to_hash).to eq(
+                  "filtered" => {
+                    "filter" => {
+                      "range" => {
+                        "created_at" => {
+                          "lt" => "now-48h",
+                        },
+                      },
+                    },
+                  },
+                )
+              end
+            end
+          end
+
+          context "and multiple operands" do
+            let(:query_string) do
+              "created:>=2days created:<=1day"
+            end
+
+            it "returns two range filters within bool filter" do
+              expect(query.query.to_hash).to eq(
+                "filtered" => {
+                  "filter" => {
+                    "bool" => {
+                      "_cache" => true,
+                      "must" => [
+                        {
+                          "range" => {
+                            "created_at" => {
+                              "gte" => "now-48h",
+                            },
+                          },
+                        },
+                        {
+                          "range" => {
+                            "created_at" => {
+                              "lte" => "now-24h",
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              )
+            end
+          end
         end
       end
     end

--- a/spec/qiita/elasticsearch/token_spec.rb
+++ b/spec/qiita/elasticsearch/token_spec.rb
@@ -1,21 +1,63 @@
 require "qiita/elasticsearch/token"
 
 RSpec.describe Qiita::Elasticsearch::Token do
-  describe "#to_s" do
-    let(:token) do
-      tokenizer.tokenize(query_string).first
-    end
+  let(:token) do
+    tokenizer.tokenize(query_string).first
+  end
 
+  let(:tokenizer) do
+  end
+
+  let(:query_string) do
+  end
+
+  describe "#to_s" do
     let(:tokenizer) do
       Qiita::Elasticsearch::Tokenizer.new(filterable_fields: ["tag"])
     end
 
-    let(:query_string) do
-      "tag:Rails"
-    end
+    context "with tag" do
+      let(:query_string) do
+        "tag:Rails"
+      end
 
-    it "returns original token string" do
-      expect(token.to_s).to eq query_string
+      it "returns original token string" do
+        expect(token.to_s).to eq query_string
+      end
+    end
+  end
+
+  describe "#has_invalid_term?" do
+    subject { token.send(:has_invalid_term?) }
+
+    context "and DateToken" do
+      let(:tokenizer) do
+        Qiita::Elasticsearch::Tokenizer.new(date_fields: ["created_at"])
+      end
+
+      context "with invalid term" do
+        let(:query_string) do
+          "created:invalid"
+        end
+
+        it { should be true }
+      end
+
+      context "with absolute date" do
+        let(:query_string) do
+          "created:>2015-04-01"
+        end
+
+        it { should be false }
+      end
+
+      context "with relative date" do
+        let(:query_string) do
+          "created:>10d"
+        end
+
+        it { should be false }
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 if ENV["CI"]
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require "simplecov"
+  SimpleCov.start
 end
 
 require File.expand_path("../qiita/elasticsearch/spec_helper", __FILE__)


### PR DESCRIPTION
Hello, I made this pull request to support filtering with date ranges not specific dates such as 2015-12-04. With this patch, the following types of filtering are supported.

```
created:>20d
```

As the type suffixes, day (d, day, days)   and year (y, year, years) are currently supported.

It would be highly appreciate it if you give me any comments or suggestions.

