### PR TITLE
Add minus sign to queries with releative date ranges

### DIFF
--- a/lib/qiita/elasticsearch/date_token.rb
+++ b/lib/qiita/elasticsearch/date_token.rb
@@ -100,6 +100,7 @@ module Qiita
       class RelativeDateExpression < BaseDateExpression
         # @note Matches to "30d" and "30days"
         PATTERN = /\A
+          -
           (?<digit>\d+)
           (?<type>d|y|day|days|year|years)
         \z/x

--- a/spec/qiita/elasticsearch/query_builder_spec.rb
+++ b/spec/qiita/elasticsearch/query_builder_spec.rb
@@ -943,7 +943,27 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
       context "and relative date expression" do
         context "and invalid type" do
           let(:query_string) do
-            "created:1h"
+            "created:-1h"
+          end
+
+          it "returns null filtered query" do
+            expect(query.query.to_hash).to eq(
+              "filtered" => {
+                "filter" => {
+                  "query" => {
+                    "ids" => {
+                      "values" => [],
+                    },
+                  },
+                },
+              },
+            )
+          end
+        end
+
+        context "and type without minus" do
+          let(:query_string) do
+            "created:1d"
           end
 
           it "returns null filtered query" do
@@ -964,7 +984,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         context "and abbreviated type" do
           context "and no range operand" do
             let(:query_string) do
-              "created:1d"
+              "created:-1d"
             end
 
             it "returns null filtered query" do
@@ -984,7 +1004,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
           context "and single operand" do
             let(:query_string) do
-              "created:<2d"
+              "created:<-2d"
             end
 
             it "returns range filter" do
@@ -1024,7 +1044,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
           context "and multiple operands" do
             let(:query_string) do
-              "created:>=2d created:<=1d"
+              "created:>=-2d created:<=-1d"
             end
 
             it "returns two range filters within bool filter" do
@@ -1060,7 +1080,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
         context "and expanted type" do
           context "and no range operand" do
             let(:query_string) do
-              "created:1day"
+              "created:-1day"
             end
 
             it "returns null filtered query" do
@@ -1080,7 +1100,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
           context "and single operand" do
             let(:query_string) do
-              "created:<2days"
+              "created:<-2days"
             end
 
             it "returns range filter" do
@@ -1120,7 +1140,7 @@ RSpec.describe Qiita::Elasticsearch::QueryBuilder do
 
           context "and multiple operands" do
             let(:query_string) do
-              "created:>=2days created:<=1day"
+              "created:>=-2days created:<=-1day"
             end
 
             it "returns two range filters within bool filter" do

--- a/spec/qiita/elasticsearch/token_spec.rb
+++ b/spec/qiita/elasticsearch/token_spec.rb
@@ -53,10 +53,18 @@ RSpec.describe Qiita::Elasticsearch::Token do
 
       context "with relative date" do
         let(:query_string) do
-          "created:>10d"
+          "created:>-10d"
         end
 
         it { should be false }
+      end
+
+      context "with relative date without minus" do
+        let(:query_string) do
+          "created:>10d"
+        end
+
+        it { should be true }
       end
     end
   end


### PR DESCRIPTION
Hello,
 
I understand that query with relative date expression is a bit misleading, since the point of the days in the queries are not clear.

For example, some understand that `created:>30d` shows documents published after 30 days from now, others think that it is documents published 30 days ago.

To avoid such a problem, I would like to add a **minus sign** to the queries. The following is the proposed query format.

```
created:>-30d
``` 

With the above format, anyone understands the specified date is past.

Any comments would be very helpful.
